### PR TITLE
return 404 errors when a file is not found in S3

### DIFF
--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -152,7 +152,13 @@ pub(crate) async fn job_output_download(
     let mut res = Response::builder();
     res = res.header(CONTENT_TYPE, "application/octet-stream");
 
-    let fr = c.file_response(t.id, o.id).await.or_500()?;
+    let Some(fr) = c.file_response(t.id, o.id).await.or_500()? else {
+        return Err(HttpError::for_client_error(
+            None,
+            hyper::StatusCode::NOT_FOUND,
+            "output file not found".into(),
+        ));
+    };
     info!(
         log,
         "job {} output {} path {:?} is in the {}", t.id, o.id, o.path, fr.info

--- a/server/src/api/worker.rs
+++ b/server/src/api/worker.rs
@@ -237,10 +237,15 @@ pub(crate) async fn worker_job_input_download(
     let mut res = Response::builder();
     res = res.header(CONTENT_TYPE, "application/octet-stream");
 
-    let fr = c
+    let Some(fr) = c
         .file_response(i.other_job.unwrap_or(i.job), i.id.unwrap())
         .await
-        .or_500()?;
+        .or_500()?
+    else {
+        return Err(HttpError::for_internal_error(
+            "input file not found".to_string(),
+        ));
+    };
     info!(
         log,
         "worker {} job {} input {} name {:?} is in the {}",


### PR DESCRIPTION
When handling a `GET /public/file/{username}/{series}/{version}/{name}` request, Buildomat queries the database to determine the file path for the provided repo, series, version, and filename. If these queries don't find a file, the endpoint returns an HTTP 404 error. However, once the file path has been determined from the database, Buildomat will then attempt to find the actual file on the filesystem, or (if it isn't found locally) from S3. If the attempt to actually load the file from the local fs/S3 doesn't find a file, the `Central::file_response` method returns an error, which is always converted into an HTTP 500 response rather than a 404. It turns out that this case occurs when a build is in progress for a particular artifact, resulting in clients seeing 500 errors for nonexistent files.

I've attempted to fix this issue by changing `Central::file_response` to return a `Result<Option<FileResponse>>` rather than a `Result<FileResponse>`. We now return `Ok(None)` in cases where the file for the requested path doesn't exist on the local filesystem or in S3, and reserve `Err` for cases where the file _is_ present but we actually couldn't open it for whatever reason.

Hopefully, this will result in 404s being returned for nonexistent files, rather than 500s. I wasn't sure how to verify that this completely resolves the issue, though --- any guidance would be very helpful. Thanks!