### PR TITLE
github: support ANSI color codes in basic renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target
 /config.toml
 /data.sqlite3
-/cache/
-/etc/
-/var/
+/cache
+/etc
+/var

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target/
+/target
 /config.toml
 /data.sqlite3
 /cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
+ "strip-ansi-escapes",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3505,6 +3506,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4113,6 +4123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4139,6 +4155,26 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "waitgroup"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-html"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73c455ae09fa2223a75114789f30ad605e9e297f79537953523366c05995f5f"
+dependencies = [
+ "regex",
+ "thiserror",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +890,7 @@ dependencies = [
 name = "buildomat-github-server"
 version = "0.0.0"
 dependencies = [
+ "ansi-to-html",
  "anyhow",
  "base64 0.22.1",
  "buildomat-bunyan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ slog = { version = "2.7", features = [ "release_max_level_debug" ] }
 slog-bunyan = "2.4"
 slog-term = "2.7"
 smf = { git = "https://github.com/illumos/smf-rs.git" }
+strip-ansi-escapes = "0.2"
 strum = { version = "0.25", features = [ "derive" ] }
 tempfile = "3.3"
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+ansi-to-html = "0.2"
 anyhow = "1"
 aws-config = "1"
 aws-credential-types = "1"

--- a/github/server/Cargo.toml
+++ b/github/server/Cargo.toml
@@ -14,6 +14,7 @@ buildomat-github-database = { path = "../database" }
 buildomat-github-hooktypes = { path = "../hooktypes" }
 buildomat-sse = { path = "../../sse" }
 
+ansi-to-html = { workspace = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }

--- a/github/server/Cargo.toml
+++ b/github/server/Cargo.toml
@@ -31,6 +31,7 @@ schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true }
+strip-ansi-escapes = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/github/server/src/variety/basic.rs
+++ b/github/server/src/variety/basic.rs
@@ -123,14 +123,14 @@ impl JobEventEx for JobEvent {
 
 fn encode_payload(payload: &str) -> Cow<'_, str> {
     /*
-     * Apply ANSI formatting to the payload after escaping it (we want to transmit the
-     * corresponding HTML tags over.
+     * Apply ANSI formatting to the payload after escaping it (we want to
+     * transmit the corresponding HTML tags over the wire).
      *
-     * One of the cases this does not handle is multiline color output split across
-     * several payloads. Doing so is quite tricky, because buildomat works with a single
-     * bash script and doesn't know when commands are completed. Other systems like
-     * GitHub Actions (as checked on 2024-09-03) don't handle multiline color either,
-     * so it's fine to punt on that.
+     * One of the cases this does not handle is multi-line color output split
+     * across several payloads. Doing so is quite tricky, because buildomat
+     * works with a single bash script and doesn't know when commands are
+     * completed. Other systems like GitHub Actions (as checked on 2024-09-03)
+     * don't handle multiline color either, so it's fine to punt on that.
      */
     ansi_to_html::convert_with_opts(
         payload,
@@ -139,10 +139,11 @@ fn encode_payload(payload: &str) -> Cow<'_, str> {
     )
     .map_or_else(
         |_| {
-            // Invalid ANSI code: only escape HTML in case the conversion to ANSI fails. To maintain
-            // consistency we use the same logic as ansi-to-html -- do not escape `/`. (There are
-            // other differences, such as ansi-to-html using decimal escapes while html_escape uses
-            // hex, but those are immaterial.)
+            // Invalid ANSI code: only escape HTML in case the conversion to
+            // ANSI fails. To maintain consistency we use the same logic as
+            // ansi-to-html -- do not escape `/`. (There are other differences,
+            // such as ansi-to-html using decimal escapes while html_escape
+            // uses hex, but those are immaterial.)
             html_escape::encode_quoted_attribute(payload)
         },
         Cow::Owned,
@@ -600,7 +601,12 @@ pub(crate) async fn run(
                      */
                     let mut line =
                         if console { "|C| " } else { "| " }.to_string();
-                    let mut chars = ev.payload.chars();
+                    // We support ANSI escapes in the log renderer, which means
+                    // that tools will generate ANSI sequences. But that
+                    // doesn't work in the GitHub renderer, so we need to
+                    // strip them out entirely.
+                    let payload = strip_ansi_escapes::strip_str(&ev.payload);
+                    let mut chars = payload.chars();
                     for _ in 0..MAX_LINE_LENGTH {
                         if let Some(c) = chars.next() {
                             line.push(c);
@@ -1783,28 +1789,31 @@ pub mod test {
             ),
             // ANSI color codes
             (
-                // Basic 16-color example -- also tests a bright color (96). (ansi-to-html 0.2.1
-                // claims not to support bright colors, but it actually does.)
+                // Basic 16-color example -- also tests a bright color (96).
+                // (ansi-to-html 0.2.1 claims not to support bright colors, but
+                // it actually does.)
                 "\x1b[31mHello, world!\x1b[0m \x1b[96mAnother message\x1b[0m",
                 "<span style='color:var(--ansi-red,#a00)'>Hello, world!</span> <span style='color:var(--ansi-bright-cyan,#5ff)'>Another message</span>",
             ),
             (
-                // Truecolor, bold, italic, underline, and also with escapes. The second code
-                // ("another") does not have a reset, but we want to ensure that we generate closing
-                // HTML tags anyway.
+                // Truecolor, bold, italic, underline, and also with escapes.
+                // The second code ("another") does not have a reset, but we
+                // want to ensure that we generate closing HTML tags anyway.
                 "\x1b[38;2;255;0;0;1;3;4mTest message\x1b[0m and &/' \x1b[38;2;0;255;0;1;3;4manother",
                 "<span style='color:#ff0000'><b><i><u>Test message</u></i></b></span> and &amp;/&#39; <span style='color:#00ff00'><b><i><u>another</u></i></b></span>",
             ),
             (
-                // Invalid ANSI code "xx" -- should be HTML-escaped but the invalid ANSI code should
-                // remain as-is. (The second ANSI code is valid, and ansi-to-html should handle it.)
+                // Invalid ANSI code "xx" -- should be HTML-escaped but the
+                // invalid ANSI code should remain as-is. (The second ANSI code
+                // is valid, and ansi-to-html should handle it.)
                 "\x1b[xx;2;255;0;0;1;3;4mTest message\x1b[0m and &/' \x1b[38;2;0;255;0;1;3;4manother",
                 "\u{1b}[xx;2;255;0;0;1;3;4mTest message and &amp;/&#39; <span style='color:#00ff00'><b><i><u>another</u></i></b></span>",
             ),
             (
-                // Invalid ANSI code "9000" -- should be HTML-escaped but the invalid ANSI code
-                // should remain as-is. (The second ANSI code is valid, but ansi-to-html's current
-                // behavior is to error out in this case. This can probably be improved.)
+                // Invalid ANSI code "9000" -- should be HTML-escaped but the
+                // invalid ANSI code should remain as-is. (The second ANSI code
+                // is valid, but ansi-to-html's current behavior is to error
+                // out in this case. This can probably be improved.)
                 "\x1b[9000;2;255;0;0;1;3;4mTest message\x1b[0m and &/' \x1b[38;2;0;255;0;1;3;4manother",
                 "\u{1b}[9000;2;255;0;0;1;3;4mTest message\u{1b}[0m and &amp;/&#x27; \u{1b}[38;2;0;255;0;1;3;4manother",
             )

--- a/github/server/www/variety/basic/style.css
+++ b/github/server/www/variety/basic/style.css
@@ -45,7 +45,7 @@ tr.s_stdout {
 }
 
 tr.s_stderr {
-    background-color: #ffe6e6;
+    background-color: #f3f3f3;
 }
 
 tr.s_task {

--- a/github/server/www/variety/basic/style.css
+++ b/github/server/www/variety/basic/style.css
@@ -2,6 +2,32 @@
  * Copyright 2024 Oxide Computer Company
  */
 
+/*
+ * The "ansi-to-html" crate uses CSS variables when emitting text that uses the
+ * classic ANSI colour palette.  Adjust the default colours to be a little
+ * darker for more contrast against "s_stdout" and "s_stderr" backgrounds,
+ * which are both quite light.
+ */
+:root {
+    --ansi-black:           #000000;
+    --ansi-red:             #b0000f;
+    --ansi-green:           #007000;
+    --ansi-yellow:          #808000;
+    --ansi-blue:            #1d1dc9;
+    --ansi-magenta:         #7027b9;
+    --ansi-cyan:            #0a8080;
+    --ansi-white:           #ffffff;
+
+    --ansi-bright-black:    #000000;
+    --ansi-bright-red:      #b20f00;
+    --ansi-bright-green:    #557000;
+    --ansi-bright-yellow:   #b44405;
+    --ansi-bright-blue:     #5f55df;
+    --ansi-bright-magenta:  #bf2c90;
+    --ansi-bright-cyan:     #30a0a0;
+    --ansi-bright-white:    #ffffff;
+}
+
 table.table_output {
     border: none;
 }
@@ -19,7 +45,7 @@ tr.s_stdout {
 }
 
 tr.s_stderr {
-    background-color: #ffd9da;
+    background-color: #ffe6e6;
 }
 
 tr.s_task {


### PR DESCRIPTION
Many tools like cargo and nextest can produce ANSI color codes, and supporting
them in the renderer can lead to a much better logging experience.

I'm not quite sure how to test this.
