### PR TITLE
allow access to GHA artifacts

### DIFF
--- a/github/server/src/main.rs
+++ b/github/server/src/main.rs
@@ -110,6 +110,7 @@ impl App {
 
         let permissions = Some(AppPermissions {
             contents: Some(Pages::Read),
+            actions: Some(Pages::Read),
             ..Default::default()
         });
 


### PR DESCRIPTION
In order to get macOS builds for a repository into the same Buildomat artefacts interface as the rest of our Buildomat jobs, I'm developing a workaround that starts a Buildomat task to wait on an actions workflow to complete, then download an artifact via the API and reupload it to Buildomat. However, GitHub has decided to put that entire section of the API under a different permission, so in order to do this the provided GITHUB_TOKEN needs to have read-only access to the actions permission.

(Note that I've not positively confirmed this currently fails in Buildomat today, but I have tested it with a fine-grained PAT and determined I'll need this permission, and that I'm able to ascertain the artifact ID and download it using only the contents and actions repository permissions.)