### PR TITLE
server, aws: add more ways to load AWS credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buildomat-aws"
+version = "0.0.0"
+dependencies = [
+ "aws-config",
+ "aws-credential-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "buildomat-bunyan"
 version = "0.0.0"
 dependencies = [
@@ -754,6 +763,7 @@ dependencies = [
  "aws-sdk-ec2",
  "aws-types",
  "base64 0.22.1",
+ "buildomat-aws",
  "buildomat-client",
  "buildomat-common",
  "buildomat-types",
@@ -1017,6 +1027,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-types",
+ "buildomat-aws",
  "buildomat-common",
  "buildomat-database",
  "buildomat-download",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	"agent",
+    "aws",
 	"bin",
 	"bunyan",
 	"client",

--- a/aws/Cargo.toml
+++ b/aws/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "buildomat-aws"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+aws-config = { workspace = true }
+aws-credential-types = { workspace = true }
+thiserror = { workspace = true }

--- a/aws/src/lib.rs
+++ b/aws/src/lib.rs
@@ -1,0 +1,68 @@
+use aws_config::default_provider::credentials::DefaultCredentialsChain;
+use aws_config::{BehaviorVersion, ConfigLoader, Region, SdkConfig};
+use aws_credential_types::Credentials;
+use aws_credential_types::provider::SharedCredentialsProvider;
+
+pub struct AwsConfig {
+    pub access_key_id: Option<String>,
+    pub secret_access_key: Option<String>,
+    pub profile: Option<String>,
+    pub region: String,
+}
+
+impl AwsConfig {
+    pub async fn into_sdk_config(self) -> Result<SdkConfig, AwsConfigError> {
+        let creds: SharedCredentialsProvider =
+            match (self.access_key_id, self.secret_access_key, self.profile) {
+                /*
+                 * When an hardcoded AWS access key is present, provide it statically.
+                 */
+                (Some(aki), Some(sak), None) => SharedCredentialsProvider::new(
+                    Credentials::new(aki, sak, None, None, "buildomat"),
+                ),
+                /*
+                 * When a profile is selected, tell the default credential chain
+                 * to use it, dynamically fetching the access key.  This could
+                 * be used authenticate with AWS SSO on a developer machine.
+                 */
+                (None, None, Some(profile)) => SharedCredentialsProvider::new(
+                    DefaultCredentialsChain::builder()
+                        .profile_name(&profile)
+                        .build()
+                        .await,
+                ),
+                /*
+                 * When nothing is selected, use the default credential chain to
+                 * dynamically fetch the access key.  This could be used to
+                 * authenticate an AWS instance using their metadata service.
+                 */
+                (None, None, None) => SharedCredentialsProvider::new(
+                    DefaultCredentialsChain::builder().build().await,
+                ),
+                /*
+                 * Provide good error messages for invalid configurations.
+                 */
+                (Some(_), None, _) | (None, Some(_), _) => {
+                    return Err(AwsConfigError::IncompleteAccessKey);
+                }
+                (Some(_), Some(_), Some(_)) => {
+                    return Err(AwsConfigError::MultipleCredentials);
+                }
+            };
+
+        Ok(ConfigLoader::default()
+            .region(Region::new(self.region))
+            .credentials_provider(creds)
+            .behavior_version(BehaviorVersion::v2026_01_12())
+            .load()
+            .await)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AwsConfigError {
+    #[error("both \"access_key_id\" and \"secret_access_key\" are required")]
+    IncompleteAccessKey,
+    #[error("cannot use both an AWS profile and hardcoded credentials")]
+    MultipleCredentials,
+}

--- a/factory/aws/Cargo.toml
+++ b/factory/aws/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
+buildomat-aws = { path = "../../aws" }
 buildomat-client = { path = "../../client" }
 buildomat-common = { path = "../../common" }
 buildomat-types = { path = "../../types" }

--- a/factory/aws/src/aws.rs
+++ b/factory/aws/src/aws.rs
@@ -8,15 +8,13 @@ use std::time::{Duration, UNIX_EPOCH};
 use std::{collections::HashMap, time::SystemTime};
 
 use anyhow::{anyhow, bail, Result};
-use aws_config::Region;
-use aws_config::{meta::region::RegionProviderChain, BehaviorVersion};
-use aws_sdk_ec2::config::Credentials;
 use aws_sdk_ec2::types::{
     BlockDeviceMapping, EbsBlockDevice, Filter,
     InstanceNetworkInterfaceSpecification, InstanceType, ResourceType, Tag,
     TagSpecification,
 };
 use base64::Engine;
+use buildomat_aws::AwsConfig;
 use buildomat_client::types::*;
 use slog::{debug, error, info, o, warn, Logger};
 
@@ -589,25 +587,14 @@ async fn aws_worker_one(
 pub(crate) async fn aws_worker(c: Arc<Central>) -> Result<()> {
     let log = c.log.new(o!("component" => "worker"));
 
-    let region = RegionProviderChain::first_try(Region::new(
-        c.config.aws.region.clone(),
-    ))
-    .region()
-    .await
-    .ok_or_else(|| anyhow!("could not select region"))?;
-    let creds = Credentials::new(
-        &c.config.aws.access_key_id,
-        &c.config.aws.secret_access_key,
-        None,
-        None,
-        "config-file",
-    );
-
-    let cfg = aws_config::defaults(BehaviorVersion::v2026_01_12())
-        .region(region)
-        .credentials_provider(creds)
-        .load()
-        .await;
+    let cfg = AwsConfig {
+        access_key_id: c.config.aws.access_key_id.clone(),
+        secret_access_key: c.config.aws.secret_access_key.clone(),
+        profile: c.config.aws.profile.clone(),
+        region: c.config.aws.region.clone(),
+    }
+    .into_sdk_config()
+    .await?;
 
     let ec2 = aws_sdk_ec2::Client::new(&cfg);
 

--- a/factory/aws/src/config.rs
+++ b/factory/aws/src/config.rs
@@ -43,8 +43,9 @@ pub(crate) struct ConfigFileAwsTarget {
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ConfigFileAws {
-    pub access_key_id: String,
-    pub secret_access_key: String,
+    pub access_key_id: Option<String>,
+    pub secret_access_key: Option<String>,
+    pub profile: Option<String>,
     pub region: String,
     pub vpc: String,
     pub subnet: String,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
+buildomat-aws = { path = "../aws" }
 buildomat-common = { path = "../common" }
 buildomat-database = { path = "../database" }
 buildomat-download = { path = "../download" }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -102,27 +102,12 @@ pub struct ConfigFileAdmin {
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigFileStorage {
-    pub access_key_id: String,
-    pub secret_access_key: String,
+    pub access_key_id: Option<String>,
+    pub secret_access_key: Option<String>,
+    pub profile: Option<String>,
     pub bucket: String,
     pub prefix: String,
     pub region: String,
-}
-
-impl ConfigFileStorage {
-    pub fn creds(&self) -> aws_credential_types::Credentials {
-        aws_credential_types::Credentials::new(
-            &self.access_key_id,
-            &self.secret_access_key,
-            None,
-            None,
-            "buildomat",
-        )
-    }
-
-    pub fn region(&self) -> aws_types::region::Region {
-        aws_types::region::Region::new(self.region.to_string())
-    }
 }
 
 pub fn load<P: AsRef<Path>>(path: P) -> Result<ConfigFile> {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -39,6 +39,7 @@ mod files;
 mod jobs;
 mod workers;
 
+use buildomat_aws::AwsConfig;
 use db::{
     AuthUser, Job, JobEvent, JobFile, JobFileId, JobId, JobOutput,
     JobOutputAndFile, Worker, WorkerEvent,
@@ -1053,12 +1054,15 @@ async fn main() -> Result<()> {
     dbfile.push("data.sqlite3");
     let db = db::Database::new(log.clone(), dbfile, config.sqlite.cache_kb)?;
 
-    let awscfg = aws_config::ConfigLoader::default()
-        .region(config.storage.region())
-        .credentials_provider(config.storage.creds())
-        .behavior_version(aws_config::BehaviorVersion::v2026_01_12())
-        .load()
-        .await;
+    let awscfg = AwsConfig {
+        access_key_id: config.storage.access_key_id.clone(),
+        secret_access_key: config.storage.secret_access_key.clone(),
+        profile: config.storage.profile.clone(),
+        region: config.storage.region.clone(),
+    }
+    .into_sdk_config()
+    .await?;
+
     let s3 = aws_sdk_s3::Client::new(&awscfg);
 
     let files = files::Files::new(log.new(o!("component" => "files")));


### PR DESCRIPTION
Right now Buildomat only allows specifying AWS credentials by writing the access key in the configuration file (of both the server and the AWS factory). That requires creating an IAM User with persistent credentials, which is not great (I'd like to avoid having credentials laying around in my disk).

This PR changes the way AWS credentials are loaded from the configuration:

* If an access key ID and a secret access key are defined, they are used to connect to AWS. This is the same behavior as today, so all existing configuration files won't change meaning.
* If a `profile` setting is present instead of `access_key_id` and `secret_access_key`, the AWS SDK will use its default credential chain to load the credentials from that profile. This is what I'd use on my developer machine to connect to my sandbox AWS account, with AWS SSO.
* If no setting is present the AWS SDK will use its default credential chain as well, this time without requesting a specific profile. This would be useful on the Buildomat server, as we could fetch temporary credentials from the EC2 Instance Role rather than leaving persistent credentials on disk.

On the implementation side, I preferred extracting the logic into a new `aws-common` crate rather than duplicating it between the server and the AWS factory. I didn't put it in the `common` crate because then everything would depend on the AWS SDK.