### PR TITLE
inherit version, license and edition from the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5277,7 +5277,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,11 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+edition = "2021"
+license = "MPL-2.0"
+version = "0.0.0"
+
 [workspace.dependencies]
 ansi-to-html = { version = "0.2", features =  [ "lazy-init" ] }
 anyhow = "1"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-agent"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [features]
 default = ['vendored-openssl']

--- a/aws/Cargo.toml
+++ b/aws/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "buildomat-aws"
-version = "0.0.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 aws-config = { workspace = true }

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 buildomat-common = { path = "../common" }

--- a/bunyan/Cargo.toml
+++ b/bunyan/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-bunyan"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-client"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-common"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-database"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-download"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/factory/aws/Cargo.toml
+++ b/factory/aws/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-factory-aws"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 buildomat-aws = { path = "../../aws" }

--- a/factory/gimlet/Cargo.toml
+++ b/factory/gimlet/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-factory-gimlet"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 buildomat-common = { path = "../../common" }

--- a/factory/lab/Cargo.toml
+++ b/factory/lab/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-factory-lab"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 buildomat-common = { path = "../../common" }

--- a/factory/propolis/Cargo.toml
+++ b/factory/propolis/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-factory-propolis"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 buildomat-common = { path = "../../common" }

--- a/github/client/Cargo.toml
+++ b/github/client/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-github-client"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/github/database/Cargo.toml
+++ b/github/database/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-github-database"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/github/dbtool/Cargo.toml
+++ b/github/dbtool/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-github-dbtool"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 buildomat-github-database = { path = "../database" }

--- a/github/ghtool/Cargo.toml
+++ b/github/ghtool/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-github-ghtool"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [features]
 default = ['vendored-openssl']

--- a/github/hooktypes/Cargo.toml
+++ b/github/hooktypes/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-github-hooktypes"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/github/server/Cargo.toml
+++ b/github/server/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-github-server"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 buildomat-bunyan = { path = "../../bunyan" }

--- a/github/testdata/Cargo.toml
+++ b/github/testdata/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-github-testdata"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/jobsh/Cargo.toml
+++ b/jobsh/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-jobsh"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 buildomat-client = { path = "../client" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-server"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 buildomat-aws = { path = "../aws" }

--- a/sse/Cargo.toml
+++ b/sse/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "buildomat-sse"
-version = "0.0.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "buildomat-types"
-version = "0.0.0"
-edition = "2021"
-license = "MPL-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "xtask"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
In https://github.com/oxidecomputer/buildomat/pull/83#discussion_r2944601348 you pointed out to keep crates at version 0.0.0 for consistency, and then I noticed in https://github.com/oxidecomputer/buildomat/pull/83#issuecomment-4073475459 that for the new crate I was adding I wasn't using the same edition as everything else. This PR switches the workspace to define the version, edition and license centrally. Now when running `cargo add` Cargo will automatically inherit those values from the workspace.