### PR TITLE
gimlet, propolis, agent: fix compilation errors on linux

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -908,6 +908,7 @@ fn zfs_get(dataset: &str, prop: &str) -> Result<String> {
     Ok(l[0].to_string())
 }
 
+#[cfg_attr(not(target_os = "illumos"), expect(dead_code))]
 fn zfs_set(dataset: &str, prop: &str, value: &str) -> Result<()> {
     let out = Command::new("/sbin/zfs")
         .arg("set")

--- a/factory/gimlet/Cargo.toml
+++ b/factory/gimlet/Cargo.toml
@@ -14,7 +14,6 @@ buildomat-types = { path = "../../types" }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 debug_parser = { workspace = true }
-devinfo = { workspace = true }
 dropshot = { workspace = true }
 getopts = { workspace = true }
 hyper = { workspace = true }
@@ -33,3 +32,6 @@ tokio = { workspace = true }
 toml = { workspace = true }
 usdt = { workspace = true }
 uuid = { workspace = true }
+
+[target.'cfg(target_os = "illumos")'.dependencies]
+devinfo = { workspace = true }

--- a/factory/gimlet/src/cleanup.rs
+++ b/factory/gimlet/src/cleanup.rs
@@ -11,8 +11,7 @@ use std::{
 use anyhow::{anyhow, bail, Result};
 use buildomat_common::*;
 
-use crate::{disks, efi};
-use disks::Slot;
+use crate::disks::{self, Slot};
 
 #[derive(Debug)]
 struct Status {
@@ -210,7 +209,10 @@ pub fn cleanup() -> Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "illumos")]
 fn prepare_m2() -> Result<()> {
+    use crate::efi;
+
     let disks = disks::list_disks()?;
 
     let Some(d) = disks.get(&Slot::M2(0)) else {
@@ -303,6 +305,11 @@ fn prepare_m2() -> Result<()> {
     println!(" * zpool {pool} created");
 
     Ok(())
+}
+
+#[cfg(not(target_os = "illumos"))]
+fn prepare_m2() -> Result<()> {
+    bail!("only works on illumos systems");
 }
 
 fn format_disks() -> Result<()> {

--- a/factory/gimlet/src/main.rs
+++ b/factory/gimlet/src/main.rs
@@ -30,6 +30,7 @@ mod cleanup;
 mod config;
 mod db;
 mod disks;
+#[cfg(target_os = "illumos")]
 mod efi;
 mod factory;
 mod host;

--- a/factory/propolis/src/ucred.rs
+++ b/factory/propolis/src/ucred.rs
@@ -5,9 +5,13 @@
 use std::os::fd::AsRawFd;
 
 use anyhow::{bail, Result};
-use libc::{getpeerucred, ucred_free, ucred_getzoneid, ucred_t, zoneid_t};
+#[cfg(target_os = "illumos")]
+use libc::{getpeerucred, ucred_free, ucred_getzoneid, ucred_t};
+
+use crate::zones::zoneid_t;
 
 pub trait PeerUCred: AsRawFd {
+    #[cfg(target_os = "illumos")]
     fn peer_ucred(&self) -> Result<UCred> {
         let fd = self.as_raw_fd();
 
@@ -20,14 +24,21 @@ pub trait PeerUCred: AsRawFd {
 
         Ok(UCred { uc })
     }
+
+    #[cfg(not(target_os = "illumos"))]
+    fn peer_ucred(&self) -> Result<UCred> {
+        bail!("only works on illumos systems");
+    }
 }
 
 impl PeerUCred for tokio::net::UnixStream {}
 
 pub struct UCred {
+    #[cfg(target_os = "illumos")]
     uc: *mut ucred_t,
 }
 
+#[cfg(target_os = "illumos")]
 impl Drop for UCred {
     fn drop(&mut self) {
         assert!(!self.uc.is_null());
@@ -38,7 +49,11 @@ impl Drop for UCred {
 
 impl UCred {
     pub fn zoneid(&self) -> Option<zoneid_t> {
+        #[cfg(target_os = "illumos")]
         let zoneid = unsafe { ucred_getzoneid(self.uc) };
+        #[cfg(not(target_os = "illumos"))]
+        let zoneid = -1;
+
         if zoneid < 0 {
             None
         } else {

--- a/factory/propolis/src/zones.rs
+++ b/factory/propolis/src/zones.rs
@@ -2,18 +2,22 @@
  * Copyright 2024 Oxide Computer Company
  */
 
-use std::ffi::CString;
-
 use anyhow::{bail, Result};
+
+#[cfg(not(target_os = "illumos"))]
+pub use libc::c_int as zoneid_t;
+#[cfg(target_os = "illumos")]
 pub use libc::zoneid_t;
 
 #[link(name = "c")]
+#[cfg(target_os = "illumos")]
 extern "C" {
     fn getzoneidbyname(name: *const libc::c_char) -> zoneid_t;
 }
 
+#[cfg(target_os = "illumos")]
 pub fn zone_name_to_id(name: &str) -> Result<Option<zoneid_t>> {
-    let cs = CString::new(name)?;
+    let cs = std::ffi::CString::new(name)?;
 
     let id = unsafe { getzoneidbyname(cs.as_ptr()) };
     if id < 0 {
@@ -31,6 +35,11 @@ pub fn zone_name_to_id(name: &str) -> Result<Option<zoneid_t>> {
     }
 
     Ok(Some(id))
+}
+
+#[cfg(not(target_os = "illumos"))]
+pub fn zone_name_to_id(_name: &str) -> Result<Option<zoneid_t>> {
+    bail!("only works on illumos systems");
 }
 
 pub fn zone_exists(name: &str) -> Result<bool> {


### PR DESCRIPTION
[As we are doing in some places already](https://github.com/oxidecomputer/buildomat/blob/234d9eb0d59cb7fc388167eb9f54fd6dc3d910c4/factory/gimlet/src/disks.rs#L99-L102), this fixes compilation errors and warnings when building and running tests on Linux. Having the list of diagnostics polluted in my editor is fairly annoying, and this fixes that.

Most changes are not invasive, except for gating the code handling zones: I can't just cfg out that module outside illumos, as it's relied upon in multiple places. What I ended up doing was creating a `ZoneId` wrapper that can be either `ZoneId(zoneid_t)` on illumos or (the stable equivalent of) `ZoneId(!)` on Linux. This way the rest of the code is not cfg'd out. Another option would be to `pub use libc::c_int as zoneid_t` on Linux if you'd prefer.

An alternative to this approach would be to compile out the entirety of the propolis and gimlet factories outside of illumos. While that would avoid some of the noise in the code, when looking at the glue between the buildomat server and the factory having LSP working on the OS-agnostic parts is useful.