### PR TITLE
add ci

### DIFF
--- a/.github/buildomat/jobs/helios.sh
+++ b/.github/buildomat/jobs/helios.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#:
+#: name = "helios"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: rust_toolchain = true
+#:
+exec .github/buildomat/test.sh

--- a/.github/buildomat/jobs/lints.sh
+++ b/.github/buildomat/jobs/lints.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#:
+#: name = "lints"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: rust_toolchain = true
+#:
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+banner fmt
+cargo fmt --check

--- a/.github/buildomat/jobs/linux.sh
+++ b/.github/buildomat/jobs/linux.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#:
+#: name = "linux"
+#: variety = "basic"
+#: target = "ubuntu-22.04"
+#: rust_toolchain = true
+#:
+exec .github/buildomat/test.sh

--- a/.github/buildomat/test.sh
+++ b/.github/buildomat/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+banner clippy
+cargo clippy --locked --tests --workspace -- -Dwarnings
+
+banner test
+cargo test --locked --workspace

--- a/aws/src/lib.rs
+++ b/aws/src/lib.rs
@@ -1,7 +1,7 @@
 use aws_config::default_provider::credentials::DefaultCredentialsChain;
 use aws_config::{BehaviorVersion, ConfigLoader, Region, SdkConfig};
-use aws_credential_types::Credentials;
 use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_credential_types::Credentials;
 
 pub struct AwsConfig {
     pub access_key_id: Option<String>,

--- a/github/server/src/variety/basic.rs
+++ b/github/server/src/variety/basic.rs
@@ -1315,13 +1315,9 @@ pub(crate) async fn details(
         }
 
         out += "<h3>Output:</h3>\n";
-        out += &output_table(
-            &bm,
-            &job,
-            local_time,
-            format!("./{}/live", cr.id),
-        )
-        .await?;
+        out +=
+            &output_table(&bm, &job, local_time, format!("./{}/live", cr.id))
+                .await?;
     }
 
     Ok(out)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.94"
+profile = "default"
+targets = ["x86_64-unknown-linux-musl"]

--- a/xtask-setup/src/factory_aws.rs
+++ b/xtask-setup/src/factory_aws.rs
@@ -57,7 +57,7 @@ pub(crate) async fn setup(ctx: &Context) -> Result<()> {
     println!("Configuring the AWS account to run buildomat jobs...");
     let vpc = create_vpc(ctx, &ec2).await?;
     let subnet = create_subnet(ctx, &ec2, &vpc).await?;
-    let sg = create_security_group(ctx, &ec2, &region, &vpc).await?;
+    let sg = create_security_group(ctx, &ec2, region, &vpc).await?;
     create_internet_gateway(ctx, &ec2, &vpc).await?;
 
     let ami = find_ubuntu_ami(&ec2, UBUNTU_RELEASE).await?;
@@ -264,14 +264,14 @@ async fn create_security_group(
         if rule.is_egress.unwrap_or(false) {
             ec2.revoke_security_group_egress()
                 .group_id(&group_id)
-                .security_group_rule_ids(&rule.security_group_rule_id.unwrap())
+                .security_group_rule_ids(rule.security_group_rule_id.unwrap())
                 .send()
                 .await
                 .context("failed to delete security group rule")?;
         } else {
             ec2.revoke_security_group_ingress()
                 .group_id(&group_id)
-                .security_group_rule_ids(&rule.security_group_rule_id.unwrap())
+                .security_group_rule_ids(rule.security_group_rule_id.unwrap())
                 .send()
                 .await
                 .context("failed to delete security group rule")?;


### PR DESCRIPTION
This PR adds a basic CI to buildomat, checking formatting, clippy, and running tests. In the future we'll probably want to extend it to also build the production binaries we run on the buildomat server, but that's a task for another time.

The bunch of the changes are fixes for Clippy. I ran a `cargo clippy --fix --tests` to address most of them, and configured a global list of lints we allow in the workspace `Cargo.toml` (rather than adding `#![allow()]` in every crate).