### PR TITLE
github: report errors happening during tasks creation

### DIFF
--- a/github/server/src/variety/basic.rs
+++ b/github/server/src/variety/basic.rs
@@ -752,7 +752,15 @@ pub(crate) async fn run(
             async move { app.load_file(&gh, &repo, &sha, &name).await }.boxed()
         }));
 
-        let tasks = tb.build(&c).await?;
+        let tasks = match tb.build(&c).await {
+            Ok(t) => t,
+            /*
+             * Report the error to the user if we couldn't create the list of
+             * tasks.  For example, this could happen if the user requested the
+             * installation of a Rust toolchain without rust-toolchain.toml.
+             */
+            Err(e) => return fatal(&mut p, cr, db, &e.to_string()),
+        };
 
         /*
          * Attach tags that allow us to more easily map the buildomat job back


### PR DESCRIPTION
Ran into this earlier today while setting up CI for buildomat itself: if a `rust-toolchain.toml` file is not present and the job description includes `rust_toolchain = true`, creating the job is supposed to fail.

The problem is, rather than reporting it as a failure to the user the GitHub server would keep trying to create the list of tasks, reporting the failure only in the server logs. This makes sure we report the failure to the user:

<img width="1055" height="254" alt="image" src="https://github.com/user-attachments/assets/9a7c0bed-8101-4c29-ac2e-db9f683b315d" />
