### PR TITLE
fix clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,14 @@ edition = "2021"
 license = "MPL-2.0"
 version = "0.0.0"
 
+[workspace.lints.clippy]
+identity_op = "allow"
+many_single_char_names = "allow"
+too_many_arguments = "allow"
+type_complexity = "allow"
+vec_init_then_push = "allow"
+wrong_self_convention = "allow"
+
 [workspace.dependencies]
 ansi-to-html = { version = "0.2", features =  [ "lazy-init" ] }
 anyhow = "1"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ['vendored-openssl']
 vendored-openssl = ['openssl/vendored']

--- a/agent/src/control/mod.rs
+++ b/agent/src/control/mod.rs
@@ -196,13 +196,13 @@ async fn cmd_address_list(mut l: Level<Stuff>) -> Result<()> {
                 let mut r = Row::default();
 
                 r.add_str("name", &addr.name);
-                r.add_str("cidr", &net.to_string());
-                r.add_str("first", &first.to_string());
-                r.add_str("last", &last.to_string());
+                r.add_str("cidr", net.to_string());
+                r.add_str("first", first.to_string());
+                r.add_str("last", last.to_string());
                 r.add_u64("count", addr.count.into());
                 r.add_str("family", "inet");
-                r.add_str("network", &net.network().to_string());
-                r.add_str("mask", &net.netmask().to_string());
+                r.add_str("network", net.network().to_string());
+                r.add_str("mask", net.netmask().to_string());
                 r.add_str("routed", if addr.routed { "yes" } else { "no" });
                 r.add_str("gateway", addr.gateway.as_deref().unwrap_or("-"));
 

--- a/agent/src/exec.rs
+++ b/agent/src/exec.rs
@@ -23,10 +23,7 @@ fn spawn_reader<T>(
 where
     T: Read + Send + 'static,
 {
-    let stream = match stream {
-        Some(stream) => stream,
-        None => return None,
-    };
+    let stream = stream?;
 
     Some(std::thread::spawn(move || {
         let mut r = BufReader::new(stream);
@@ -329,11 +326,7 @@ fn run_common(
                     )
                     .unwrap();
                 }
-                let code = if let Some(code) = es.code() {
-                    code
-                } else {
-                    std::i32::MAX
-                };
+                let code = es.code().unwrap_or(std::i32::MAX);
                 tx.blocking_send(ab.exit(&start, &end, code)).unwrap();
                 stdio_warning
             }

--- a/agent/src/exec.rs
+++ b/agent/src/exec.rs
@@ -381,7 +381,6 @@ impl BackgroundProcesses {
         BackgroundProcesses { rx, tx, procs: Default::default() }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn start<'a, A, E>(
         &mut self,
         name: &str,

--- a/agent/src/exec.rs
+++ b/agent/src/exec.rs
@@ -294,8 +294,7 @@ fn run_common(
                  * process.
                  */
                 if ab.bgproc.is_none() {
-                    tx.blocking_send(ab.exit(&start, &end, std::i32::MAX))
-                        .unwrap();
+                    tx.blocking_send(ab.exit(&start, &end, i32::MAX)).unwrap();
                 }
 
                 false
@@ -326,7 +325,7 @@ fn run_common(
                     )
                     .unwrap();
                 }
-                let code = es.code().unwrap_or(std::i32::MAX);
+                let code = es.code().unwrap_or(i32::MAX);
                 tx.blocking_send(ab.exit(&start, &end, code)).unwrap();
                 stdio_warning
             }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1094,7 +1094,7 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
         let status = Command::new("/sbin/zfs")
             .arg("create")
             .arg("-o")
-            .arg(&format!("mountpoint={}", INPUT_PATH))
+            .arg(format!("mountpoint={INPUT_PATH}"))
             .arg(INPUT_DATASET)
             .env_clear()
             .current_dir("/")

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -2,8 +2,6 @@
  * Copyright 2024 Oxide Computer Company
  */
 
-#![allow(clippy::many_single_char_names)]
-
 use std::collections::VecDeque;
 use std::env;
 use std::fs::{File, OpenOptions};

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1171,8 +1171,8 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
         let binmd = std::fs::symlink_metadata("/bin")?;
         if binmd.is_dir() {
             std::os::unix::fs::symlink(
-                &format!("../usr/bin/{CONTROL_PROGRAM}"),
-                &format!("/bin/{CONTROL_PROGRAM}"),
+                format!("../usr/bin/{CONTROL_PROGRAM}"),
+                format!("/bin/{CONTROL_PROGRAM}"),
             )?;
         }
     }

--- a/aws/Cargo.toml
+++ b/aws/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 aws-config = { workspace = true }
 aws-credential-types = { workspace = true }

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-common = { path = "../common" }
 buildomat-client = { path = "../client" }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -1228,7 +1228,7 @@ async fn do_job_store_list(mut l: Level<Stuff>) -> Result<()> {
         );
         r.add_str(
             "updated",
-            &ent.time_update.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            ent.time_update.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         );
 
         t.add_row(r);
@@ -1353,7 +1353,7 @@ async fn do_user_list(mut l: Level<Stuff>) -> Result<()> {
         r.add_str("name", &u.name);
         r.add_str(
             "creation",
-            &u.time_create.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            u.time_create.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         );
         r.add_age("age", u.time_create.age());
         t.add_row(r);

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -2,8 +2,6 @@
  * Copyright 2025 Oxide Computer Company
  */
 
-#![allow(clippy::many_single_char_names)]
-
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::{Read, Write};
 use std::path::PathBuf;

--- a/bunyan/Cargo.toml
+++ b/bunyan/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/factory/aws/Cargo.toml
+++ b/factory/aws/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-aws = { path = "../../aws" }
 buildomat-client = { path = "../../client" }

--- a/factory/aws/src/aws.rs
+++ b/factory/aws/src/aws.rs
@@ -69,7 +69,7 @@ impl Instance {
                     .try_into()
                     .unwrap();
 
-                (if when <= now { now - when } else { 0 }) / 1000
+                now.saturating_sub(when) / 1000
             })
             .unwrap_or(0)
     }
@@ -203,7 +203,7 @@ async fn create_instance(
             Ok(res) => {
                 instances = res
                     .instances()
-                    .into_iter()
+                    .iter()
                     .map(|i| Instance::from((i, config.aws.tag.as_str())))
                     .collect();
                 break;
@@ -245,13 +245,12 @@ async fn instances(
     Ok(res
         .reservations()
         .iter()
-        .map(|r| {
+        .flat_map(|r| {
             r.instances().iter().map(|i| {
                 let i = Instance::from((i, tag));
                 (i.id.to_string(), i)
             })
         })
-        .flatten()
         .collect())
 }
 

--- a/factory/aws/src/aws.rs
+++ b/factory/aws/src/aws.rs
@@ -447,7 +447,7 @@ async fn aws_worker_one(
              * There is a record of a particular instance ID for this worker.
              * Check to see if that instance exists.
              */
-            if let Some(i) = insts.get(&instance_id.to_string()) {
+            if let Some(i) = insts.get(instance_id) {
                 if i.state == "terminated" {
                     /*
                      * The instance exists, but is terminated.  Delete the

--- a/factory/aws/src/main.rs
+++ b/factory/aws/src/main.rs
@@ -72,7 +72,7 @@ impl Central {
          * Allow the per-target diagnostic configuration to override the base
          * diagnostic configuration.
          */
-        Ok(self.config.diag.apply_overrides(&t.diag).build()?)
+        self.config.diag.apply_overrides(&t.diag).build()
     }
 }
 

--- a/factory/gimlet/Cargo.toml
+++ b/factory/gimlet/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-common = { path = "../../common" }
 buildomat-database = { path = "../../database" }

--- a/factory/gimlet/src/cleanup.rs
+++ b/factory/gimlet/src/cleanup.rs
@@ -109,7 +109,7 @@ pub fn setup() -> Result<()> {
             bail!("giving up after {MAX_TIME} seconds");
         }
 
-        if let Ok(st) = svcs(&fmri) {
+        if let Ok(st) = svcs(fmri) {
             if st.next.is_none() && st.current == "ON" {
                 println!(" * {fmri} now online!");
                 break;
@@ -124,7 +124,7 @@ pub fn setup() -> Result<()> {
      * only be one!
      */
     let pools = zpool_unimported_list()?;
-    if pools.len() == 0 {
+    if pools.is_empty() {
         bail!("no unimported pool found!");
     } else if pools.len() > 1 {
         bail!("more than one unimported pool found!");
@@ -136,14 +136,14 @@ pub fn setup() -> Result<()> {
     };
 
     println!(" * importing pool {pool:?}...");
-    zpool_import(&pool)?;
+    zpool_import(pool)?;
 
     /*
      * Update the BSU symlink:
      */
     std::fs::create_dir_all("/pool/bsu")?;
     std::fs::remove_file("/pool/bsu/0").ok();
-    std::os::unix::fs::symlink(&format!("../int/{pool_id}"), "/pool/bsu/0")?;
+    std::os::unix::fs::symlink(format!("../int/{pool_id}"), "/pool/bsu/0")?;
 
     /*
      * Create the swap device:

--- a/factory/gimlet/src/cleanup.rs
+++ b/factory/gimlet/src/cleanup.rs
@@ -254,7 +254,7 @@ fn prepare_m2() -> Result<()> {
         let p = &mut vtoc.parts_mut()[i];
         p.p_tag = efi::sys::V_USR;
         p.p_start = next_start;
-        p.p_size = size.into();
+        p.p_size = size;
         next_start = next_start.checked_add(size).unwrap();
     }
 
@@ -289,11 +289,11 @@ fn prepare_m2() -> Result<()> {
         .env_clear()
         .arg("create")
         .arg("-O")
-        .arg(&format!("mountpoint=/pool/int/{id}"))
+        .arg(format!("mountpoint=/pool/int/{id}"))
         .arg("-O")
         .arg("compress=on")
         .arg(&pool)
-        .arg(&format!("{}s5", d.name))
+        .arg(format!("{}s5", d.name))
         .output()?;
 
     if !out.status.success() {

--- a/factory/gimlet/src/db/mod.rs
+++ b/factory/gimlet/src/db/mod.rs
@@ -167,7 +167,7 @@ impl Database {
             /*
              * Fetch the current instance state:
              */
-            let i: Instance = h.get_row(Instance::find(&id))?;
+            let i: Instance = h.get_row(Instance::find(id))?;
 
             match i.state {
                 InstanceState::Preinstall

--- a/factory/gimlet/src/disks.rs
+++ b/factory/gimlet/src/disks.rs
@@ -121,7 +121,7 @@ pub fn list_disks() -> Result<Disks> {
                            slice: u32|
      -> Result<Option<devinfo::DevLink>> {
         let mut paths = links
-            .links_for_path(&device)?
+            .links_for_path(device)?
             .into_iter()
             .filter(|l| {
                 l.linktype() == devinfo::DevLinkType::Primary
@@ -193,18 +193,18 @@ pub fn list_disks() -> Result<Disks> {
                  */
                 let device = m.devfs_path()?;
 
-                Ok((0..=8)
+                (0..=8)
                     .map(|num| {
                         Ok(slice_from_path(&device, num)?.map(|link| {
                             (num, m.spec_type(), link.path().to_owned())
                         }))
                     })
-                    .collect::<Result<Vec<_>>>()?)
+                    .collect::<Result<Vec<_>>>()
             })
             .collect::<Result<Vec<_>>>()?
             .into_iter()
             .flatten()
-            .filter_map(|v| v)
+            .flatten()
             .collect::<Vec<_>>();
 
         /*

--- a/factory/gimlet/src/host.rs
+++ b/factory/gimlet/src/host.rs
@@ -71,7 +71,7 @@ impl Host {
         info!(&self.log, "powering off");
         let res =
             self.hiffy("Sequencer.set_state").arg("state", "A2").call()?;
-        if res.value.to_string().trim().to_string() != "Changed" {
+        if res.value.to_string().trim() != "Changed" {
             bail!("unexpected power off result: {:?}", res.stdout);
         }
 
@@ -87,7 +87,7 @@ impl Host {
         info!(&self.log, "powering on");
         let res =
             self.hiffy("Sequencer.set_state").arg("state", "A0").call()?;
-        if res.value.to_string().trim().to_string() != "Changed" {
+        if res.value.to_string().trim() != "Changed" {
             bail!("unexpected power on result: {:?}", res.stdout);
         }
 
@@ -748,7 +748,7 @@ impl HostManager {
                 Ok(())
             }
             HostState::Cleaning(cst) => {
-                let mut new_cst = cst.clone();
+                let mut new_cst = *cst;
 
                 {
                     let mut l = self.locked.lock().unwrap();
@@ -827,7 +827,7 @@ impl HostManager {
                 Ok(())
             }
             HostState::Starting(sst, hgs) => {
-                let mut new_sst = sst.clone();
+                let mut new_sst = *sst;
 
                 {
                     let mut l = self.locked.lock().unwrap();
@@ -854,7 +854,7 @@ impl HostManager {
                     }
                 }
 
-                if let Err(e) = self.thread_starting(&mut new_sst, &hgs) {
+                if let Err(e) = self.thread_starting(&mut new_sst, hgs) {
                     error!(log, "starting error: {e}");
                 }
 
@@ -923,7 +923,7 @@ impl HostManager {
 
                 let pb = sys
                     .ssh_exec("svcs -Ho sta,nsta svc:/site/postboot:default")?;
-                let t = pb.out.trim().split_whitespace().collect::<Vec<_>>();
+                let t = pb.out.split_whitespace().collect::<Vec<_>>();
                 if t.len() != 2 || t[0] == "ON" || t[1] == "-" {
                     bail!("postboot not ready: {t:?}");
                 }
@@ -1006,7 +1006,7 @@ impl HostManager {
 
                 let pb = sys
                     .ssh_exec("svcs -Ho sta,nsta svc:/site/postboot:default")?;
-                let t = pb.out.trim().split_whitespace().collect::<Vec<_>>();
+                let t = pb.out.split_whitespace().collect::<Vec<_>>();
                 if t.len() != 2 || t[0] == "ON" || t[1] == "-" {
                     bail!("postboot not ready: {t:?}");
                 }

--- a/factory/gimlet/src/humility.rs
+++ b/factory/gimlet/src/humility.rs
@@ -57,7 +57,7 @@ impl ValueExt for Value {
                                 bail!("expected a hex number, got {t:?}");
                             };
 
-                            out.push(u8::from_str_radix(&hex, 16)?);
+                            out.push(u8::from_str_radix(hex, 16)?);
                         }
                         _ => bail!("list should only contain terms"),
                     }

--- a/factory/gimlet/src/instance.rs
+++ b/factory/gimlet/src/instance.rs
@@ -84,7 +84,7 @@ async fn instance_worker_start(
         }
         instances_with_workers.insert(id.clone());
 
-        let c = Arc::clone(&c);
+        let c = Arc::clone(c);
         let log = log.new(o!(
             "component" => "instance_worker",
             "instance" => id.to_string(),

--- a/factory/lab/Cargo.toml
+++ b/factory/lab/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-common = { path = "../../common" }
 buildomat-database = { path = "../../database" }

--- a/factory/lab/src/db/tables/instance.rs
+++ b/factory/lab/src/db/tables/instance.rs
@@ -180,7 +180,7 @@ mod test {
     use super::InstanceState;
     use std::str::FromStr;
 
-    const INSTANCE_STATES: &'static [(&'static str, InstanceState)] = &[
+    const INSTANCE_STATES: &[(&str, InstanceState)] = &[
         ("preboot", InstanceState::Preboot),
         ("booted", InstanceState::Booted),
         ("destroying", InstanceState::Destroying),

--- a/factory/lab/src/minder.rs
+++ b/factory/lab/src/minder.rs
@@ -149,7 +149,7 @@ impl CentralExt for Central {
         &self,
         name: &str,
     ) -> HResult<&super::config::ConfigFileHost> {
-        if let Some(h) = self.hosts.get(&name.to_string()) {
+        if let Some(h) = self.hosts.get(name) {
             Ok(&h.config)
         } else {
             Err(dropshot::HttpError::for_client_error(

--- a/factory/lab/src/minder.rs
+++ b/factory/lab/src/minder.rs
@@ -74,7 +74,7 @@ impl FormatScript {
             .replace("%BASEURL%", &self.host_config.lab_baseurl)
             .replace("%HOST%", &self.host_config.nodename)
             .replace("%CONSOLE%", &self.host_config.console)
-            .replace("%BOOTARGS%", &bootargs)
+            .replace("%BOOTARGS%", bootargs)
             .replace("%COREURL%", &self.coreurl);
 
         if let Some(key) = self.key.as_deref() {

--- a/factory/propolis/Cargo.toml
+++ b/factory/propolis/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-common = { path = "../../common" }
 buildomat-database = { path = "../../database" }

--- a/factory/propolis/src/main.rs
+++ b/factory/propolis/src/main.rs
@@ -39,7 +39,7 @@ impl Central {
          * Allow the per-target diagnostic configuration to override the base
          * diagnostic configuration.
          */
-        Ok(self.config.diag.apply_overrides(&t.diag).build()?)
+        self.config.diag.apply_overrides(&t.diag).build()
     }
 }
 

--- a/factory/propolis/src/vm.rs
+++ b/factory/propolis/src/vm.rs
@@ -461,8 +461,8 @@ async fn instance_worker_one(
                     include_str!("../smf/serial.xml"),
                 ),
             ] {
-                std::fs::write(&vmdir.join(&format!("{name}.sh")), script)?;
-                std::fs::write(&smfdir.join(format!("{name}.xml")), bundle)?;
+                std::fs::write(vmdir.join(format!("{name}.sh")), script)?;
+                std::fs::write(smfdir.join(format!("{name}.xml")), bundle)?;
             }
 
             std::fs::write(&siteprofile, include_str!("../smf/site.xml"))?;

--- a/github/client/Cargo.toml
+++ b/github/client/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/github/database/Cargo.toml
+++ b/github/database/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/github/database/src/tables/check_run.rs
+++ b/github/database/src/tables/check_run.rs
@@ -219,7 +219,7 @@ mod test {
     use super::CheckRunVariety;
     use std::str::FromStr;
 
-    const CHECK_RUN_VARIETIES: &'static [(&'static str, CheckRunVariety)] = &[
+    const CHECK_RUN_VARIETIES: &[(&str, CheckRunVariety)] = &[
         ("control", CheckRunVariety::Control),
         ("always_pass", CheckRunVariety::AlwaysPass),
         ("fail_first", CheckRunVariety::FailFirst),

--- a/github/database/src/tables/check_suite.rs
+++ b/github/database/src/tables/check_suite.rs
@@ -61,7 +61,7 @@ impl From<jobfile::JobFile> for JobFile {
             content,
             dependencies: dependencies
                 .into_iter()
-                .map(|(a, b)| (a.into(), b.into()))
+                .map(|(a, b)| (a, b.into()))
                 .collect(),
         }
     }

--- a/github/database/src/tables/user.rs
+++ b/github/database/src/tables/user.rs
@@ -104,7 +104,7 @@ mod test {
     use super::UserType;
     use std::str::FromStr;
 
-    const USER_TYPES: &'static [(&'static str, UserType)] = &[
+    const USER_TYPES: &[(&str, UserType)] = &[
         ("user", UserType::User),
         ("bot", UserType::Bot),
         ("org", UserType::Organisation),

--- a/github/dbtool/Cargo.toml
+++ b/github/dbtool/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-github-database = { path = "../database" }
 buildomat-github-hooktypes = { path = "../hooktypes" }

--- a/github/dbtool/src/main.rs
+++ b/github/dbtool/src/main.rs
@@ -69,7 +69,7 @@ impl Stuff {
         std::fs::DirBuilder::new().mode(0o700).recursive(true).create(&out)?;
         out.push(set);
         std::fs::DirBuilder::new().mode(0o700).recursive(true).create(&out)?;
-        out.push(format!("{}.json", file));
+        out.push(format!("{file}.json"));
         Ok(out)
     }
 }

--- a/github/dbtool/src/main.rs
+++ b/github/dbtool/src/main.rs
@@ -69,7 +69,7 @@ impl Stuff {
         std::fs::DirBuilder::new().mode(0o700).recursive(true).create(&out)?;
         out.push(set);
         std::fs::DirBuilder::new().mode(0o700).recursive(true).create(&out)?;
-        out.push(&format!("{}.json", file));
+        out.push(format!("{}.json", file));
         Ok(out)
     }
 }
@@ -290,7 +290,7 @@ async fn do_delivery_list(mut l: Level<Stuff>) -> Result<()> {
         );
         r.add_str(
             "ack",
-            &del.ack.map(|n| n.to_string()).unwrap_or_else(|| "-".to_string()),
+            del.ack.map(|n| n.to_string()).unwrap_or_else(|| "-".to_string()),
         );
 
         let seq = del.seq;
@@ -371,10 +371,10 @@ async fn do_check_suite_list(mut l: Level<Stuff>) -> Result<()> {
 
     for suite in l.context().db().list_check_suites()? {
         let mut r = Row::default();
-        r.add_str("id", &suite.id.to_string());
+        r.add_str("id", suite.id.to_string());
         r.add_u64("ghid", suite.github_id as u64);
         r.add_u64("repo", suite.repo as u64);
-        r.add_str("state", &format!("{:?}", suite.state));
+        r.add_str("state", format!("{:?}", suite.state));
         r.add_str("ssha", &suite.head_sha[0..SHORT_SHA_LEN]);
         r.add_str("sha", suite.head_sha);
         r.add_str("branch", suite.head_branch.as_deref().unwrap_or("-"));
@@ -407,14 +407,14 @@ async fn do_check_suite_runs(mut l: Level<Stuff>) -> Result<()> {
 
     for run in l.context().db().list_check_runs_for_suite(csid)? {
         let mut r = Row::default();
-        r.add_str("id", &run.id.to_string());
+        r.add_str("id", run.id.to_string());
         r.add_flags("flags")
             .flag('A', run.active)
             .flag('F', run.flushed)
             .build();
         r.add_str("active", if run.active { "yes" } else { "no" });
         r.add_str("flushed", if run.flushed { "yes" } else { "no" });
-        r.add_str("variety", &run.variety.to_string());
+        r.add_str("variety", run.variety.to_string());
         r.add_str("name", &run.name);
 
         t.add_row(r);

--- a/github/ghtool/Cargo.toml
+++ b/github/ghtool/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ['vendored-openssl']
 vendored-openssl = ['openssl/vendored']

--- a/github/hooktypes/Cargo.toml
+++ b/github/hooktypes/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/github/server/Cargo.toml
+++ b/github/server/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-bunyan = { path = "../../bunyan" }
 buildomat-client = { path = "../../client" }

--- a/github/server/src/http.rs
+++ b/github/server/src/http.rs
@@ -359,7 +359,7 @@ async fn details(
     Ok(hyper::Response::builder()
         .status(hyper::StatusCode::OK)
         .header(hyper::header::CONTENT_TYPE, "text/html; charset=utf-8")
-        .header(hyper::header::CONTENT_LENGTH, out.as_bytes().len())
+        .header(hyper::header::CONTENT_LENGTH, out.len())
         .body(Body::from(out))?)
 }
 
@@ -831,7 +831,7 @@ async fn status_impl(
     Ok(hyper::Response::builder()
         .status(hyper::StatusCode::OK)
         .header(hyper::header::CONTENT_TYPE, "text/html; charset=utf-8")
-        .header(hyper::header::CONTENT_LENGTH, out.as_bytes().len())
+        .header(hyper::header::CONTENT_LENGTH, out.len())
         .body(Body::from(out))?)
 }
 
@@ -1020,7 +1020,7 @@ async fn branch_to_commit(
     Ok(hyper::Response::builder()
         .status(hyper::StatusCode::OK)
         .header(hyper::header::CONTENT_TYPE, "text/plain")
-        .header(hyper::header::CONTENT_LENGTH, body.as_bytes().len())
+        .header(hyper::header::CONTENT_LENGTH, body.len())
         .body(body.into())?)
 }
 

--- a/github/server/src/main.rs
+++ b/github/server/src/main.rs
@@ -301,7 +301,7 @@ impl App {
     fn buildomat(&self, repo: &Repository) -> buildomat_client::Client {
         buildomat_client::ClientBuilder::new(&self.config.buildomat.url)
             .bearer_token(&self.config.buildomat.token)
-            .delegated_user(&self.buildomat_username(repo))
+            .delegated_user(self.buildomat_username(repo))
             .build()
             .unwrap()
     }

--- a/github/server/src/main.rs
+++ b/github/server/src/main.rs
@@ -2,8 +2,6 @@
  * Copyright 2025 Oxide Computer Company
  */
 
-#![allow(clippy::vec_init_then_push)]
-
 use anyhow::{anyhow, bail, Context, Result};
 use base64::Engine;
 use buildomat_common::*;

--- a/github/server/src/main.rs
+++ b/github/server/src/main.rs
@@ -1432,7 +1432,6 @@ async fn flush_check_runs(
                 actions: out.actions,
                 started_at: out.started_at,
                 completed_at: out.completed_at,
-                ..Default::default()
             };
 
             let res = gh

--- a/github/server/src/variety/basic.rs
+++ b/github/server/src/variety/basic.rs
@@ -732,11 +732,11 @@ pub(crate) async fn run(
          * We pass several GitHub-specific environment variables to tasks in the
          * job:
          */
-        tb.env("GITHUB_REPOSITORY", &format!("{}/{}", repo.owner, repo.name));
+        tb.env("GITHUB_REPOSITORY", format!("{}/{}", repo.owner, repo.name));
         tb.env("GITHUB_SHA", &cs.head_sha);
         if let Some(branch) = cs.head_branch.as_deref() {
             tb.env("GITHUB_BRANCH", branch);
-            tb.env("GITHUB_REF", &format!("refs/heads/{}", branch));
+            tb.env("GITHUB_REF", format!("refs/heads/{}", branch));
         }
 
         let app0 = app.clone();
@@ -1108,7 +1108,7 @@ pub(crate) async fn artefact(
                     .header(hyper::header::CONTENT_TYPE, "text/html")
                     .header(hyper::header::CONTENT_LENGTH, md.len())
                     .body(Body::wrap(StreamBody::new(
-                        stream.map_ok(|b| Frame::data(b)),
+                        stream.map_ok(Frame::data),
                     )))?,
             ));
         }
@@ -1172,7 +1172,7 @@ pub(crate) async fn artefact(
                     .header(hyper::header::CONTENT_TYPE, ct)
                     .header(hyper::header::CONTENT_LENGTH, cl)
                     .body(Body::wrap(StreamBody::new(
-                        backend.into_inner_stream().map_ok(|b| Frame::data(b)),
+                        backend.into_inner_stream().map_ok(Frame::data),
                     )))?,
             ));
         }
@@ -1319,7 +1319,7 @@ pub(crate) async fn details(
             &bm,
             &job,
             local_time,
-            format!("./{}/live", cr.id.to_string()),
+            format!("./{}/live", cr.id),
         )
         .await?;
     }

--- a/github/server/src/variety/basic.rs
+++ b/github/server/src/variety/basic.rs
@@ -736,7 +736,7 @@ pub(crate) async fn run(
         tb.env("GITHUB_SHA", &cs.head_sha);
         if let Some(branch) = cs.head_branch.as_deref() {
             tb.env("GITHUB_BRANCH", branch);
-            tb.env("GITHUB_REF", format!("refs/heads/{}", branch));
+            tb.env("GITHUB_REF", format!("refs/heads/{branch}"));
         }
 
         let app0 = app.clone();

--- a/github/testdata/Cargo.toml
+++ b/github/testdata/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/jobsh/Cargo.toml
+++ b/jobsh/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-client = { path = "../client" }
 buildomat-common = { path = "../common" }

--- a/jobsh/src/variety/basic.rs
+++ b/jobsh/src/variety/basic.rs
@@ -95,7 +95,7 @@ pub async fn output_table(
 
         for ev in page {
             minseq = ev.seq + 1;
-            payload_size += ev.payload.as_bytes().len();
+            payload_size += ev.payload.len();
             events.push(ev);
 
             if payload_size > PAYLOAD_SIZE_MAX {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-aws = { path = "../aws" }
 buildomat-common = { path = "../common" }

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -2361,7 +2361,7 @@ impl Database {
          */
         let max_val_count = 100;
         let max_val_kib = 10;
-        if value.as_bytes().len() > max_val_kib * 1024 {
+        if value.len() > max_val_kib * 1024 {
             conflict!("maximum value size is {max_val_kib}KiB");
         }
 

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -1040,7 +1040,6 @@ impl Database {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn i_worker_event_insert(
         &self,
         h: &mut Handle,
@@ -2485,7 +2484,6 @@ impl Database {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn i_job_event_insert(
         &self,
         h: &mut Handle,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,9 +2,6 @@
  * Copyright 2025 Oxide Computer Company
  */
 
-#![allow(clippy::many_single_char_names)]
-#![allow(clippy::too_many_arguments)]
-
 use std::collections::VecDeque;
 use std::io::{Seek, Write};
 use std::path::PathBuf;
@@ -1132,7 +1129,6 @@ async fn main() -> Result<()> {
     });
 
     let server = HttpServerStarter::new(
-        #[allow(clippy::needless_update)]
         &ConfigDropshot {
             default_request_body_max_bytes: 10 * 1024 * 1024,
             bind_address,

--- a/sse/Cargo.toml
+++ b/sse/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 

--- a/xtask-setup/Cargo.toml
+++ b/xtask-setup/Cargo.toml
@@ -4,6 +4,9 @@ edition.workspace = true
 license.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 buildomat-common = { path = "../common" }
 buildomat-client = { path = "../client" }

--- a/xtask-setup/src/github_server/mod.rs
+++ b/xtask-setup/src/github_server/mod.rs
@@ -219,7 +219,7 @@ async fn create_github_app(
     /*
      * Exchange the code we received in the callback with the app private key.
      */
-    Ok(reqwest::Client::new()
+    reqwest::Client::new()
         .post(format!(
             "https://api.github.com/app-manifests/{callback_code}/conversions"
         ))
@@ -231,7 +231,7 @@ async fn create_github_app(
         .context("failed to ask GitHub to finish creating the GitHub App")?
         .json()
         .await
-        .context("failed to deserialize response from GitHub")?)
+        .context("failed to deserialize response from GitHub")
 }
 
 struct CreationServerState {

--- a/xtask-setup/src/main.rs
+++ b/xtask-setup/src/main.rs
@@ -131,9 +131,9 @@ async fn run_stdout(command: &mut Command) -> Result<String> {
         bail!("\"{}\" failed with {}", name.display(), output.status);
     }
 
-    Ok(String::from_utf8(output.stdout).with_context(|| {
+    String::from_utf8(output.stdout).with_context(|| {
         format!("\"{}\" emitted non-UTF-8 data to stdout", name.display())
-    })?)
+    })
 }
 
 fn cargo() -> Command {

--- a/xtask-setup/src/main.rs
+++ b/xtask-setup/src/main.rs
@@ -48,8 +48,10 @@ async fn main() -> Result<()> {
         setup_name
     };
 
-    let mut input_theme = ColorfulTheme::default();
-    input_theme.success_prefix = dialoguer::console::style(String::new());
+    let input_theme = ColorfulTheme {
+        success_prefix: dialoguer::console::style(String::new()),
+        ..ColorfulTheme::default()
+    };
 
     let ctx = Context { root, setup_name, input_theme };
 

--- a/xtask-setup/src/server.rs
+++ b/xtask-setup/src/server.rs
@@ -207,7 +207,7 @@ async fn create_s3_bucket(
     let region_idx = Select::with_theme(&ctx.input_theme)
         .with_prompt("Region to create the bucket into")
         .default(0)
-        .items(&regions)
+        .items(regions)
         .interact()?;
     let region = regions[region_idx];
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 tempfile = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -439,7 +439,7 @@ fn local_buildomat_server() -> Result<()> {
          * executed from the correct working directory.
          */
         .arg("-f")
-        .arg(&local.join("config.toml"))
+        .arg(local.join("config.toml"))
         .current_dir(&local)
         .exec()
         .into())
@@ -450,7 +450,7 @@ fn local_buildomat_factory_aws() -> Result<()> {
     Err(cargo()
         .args(["run", "--bin", "buildomat-factory-aws", "--"])
         .arg("-f")
-        .arg(&local.join("config.toml"))
+        .arg(local.join("config.toml"))
         .exec()
         .into())
 }


### PR DESCRIPTION
This PR fixes Clippy lints across the codebase, and configures a workspace-wide list of lints we allow. The bulk of the changes were done by running `cargo clippy --tests --fix`, with a few manual changes in the following commits for fixes not performed automatically.