### PR TITLE
 agent: implement post tasks 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,6 @@ root = true
 
 [*]
 max_line_length = 80
+
+[*.js]
+indent_style = tab

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ version = "0.0.0"
 [workspace.lints.clippy]
 identity_op = "allow"
 many_single_char_names = "allow"
+should_implement_trait = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
 vec_init_then_push = "allow"

--- a/agent/src/control/mod.rs
+++ b/agent/src/control/mod.rs
@@ -14,7 +14,7 @@ use tokio::{
 };
 
 use protocol::{
-    Decoder, FactoryInfo, Message, Payload, PayloadReq, PayloadRes,
+    Decoder, FactoryInfo, Message, Payload, PayloadReq, PayloadRes, Process,
 };
 
 pub(crate) mod protocol;
@@ -387,30 +387,8 @@ async fn cmd_process_start(mut l: Level<Stuff>) -> Result<()> {
 
     let a = args!(l);
 
-    if a.args().len() < 2 {
-        bad_args!(l, "specify at least a process name and a command to run");
-    }
-
-    let payload = PayloadReq::ProcessStart {
-        name: a.args()[0].to_string(),
-        cmd: a.args()[1].to_string(),
-        args: a.args().iter().skip(2).cloned().collect::<Vec<_>>(),
-
-        /*
-         * The process will actually be spawned by the agent, which is
-         * running under service management.  To aid the user, we want
-         * to forward the environment and current directory so that the
-         * process can be started as if it were run from the job program
-         * itself.
-         */
-        env: std::env::vars_os().collect::<Vec<_>>(),
-        pwd: std::env::current_dir()?.to_str().unwrap().to_string(),
-
-        uid: unsafe { libc::geteuid() },
-        gid: unsafe { libc::getegid() },
-    };
-
-    match l.context_mut().req(payload).await? {
+    let req = PayloadReq::ProcessStart(build_process(&l, a.args())?);
+    match l.context_mut().req(req).await? {
         PayloadRes::Error(e) => {
             /*
              * This request is purely local to the agent, so an
@@ -421,6 +399,30 @@ async fn cmd_process_start(mut l: Level<Stuff>) -> Result<()> {
         PayloadRes::Ack => Ok(()),
         other => bail!("unexpected response: {other:?}"),
     }
+}
+
+fn build_process(l: &Level<Stuff>, args: &[String]) -> Result<Process> {
+    if args.len() < 2 {
+        bad_args!(l, "specify at least a process name and a command to run");
+    }
+
+    Ok(Process {
+        name: args[0].clone(),
+        cmd: args[1].clone(),
+        args: args[2..].to_vec(),
+
+        /*
+         * The process will actually be spawned by the agent, which is
+         * running under service management.  To aid the user, we want
+         * to forward the environment and current directory so that the
+         * process can be started as if it were run from the job program
+         * itself.
+         */
+        env: std::env::vars_os().collect(),
+        pwd: std::env::current_dir()?.into_os_string(),
+        uid: unsafe { libc::geteuid() },
+        gid: unsafe { libc::getegid() },
+    })
 }
 
 async fn factory_info(s: &mut Stuff) -> Result<FactoryInfo> {

--- a/agent/src/control/mod.rs
+++ b/agent/src/control/mod.rs
@@ -123,6 +123,7 @@ pub async fn main() -> Result<()> {
     l.cmd("store", "access the job store", cmd!(cmd_store))?;
     l.cmd("address", "manage IP addresses for this job", cmd!(cmd_address))?;
     l.cmd("process", "manage background processes", cmd!(cmd_process))?;
+    l.cmd("post", "manage post tasks", cmd!(cmd_post))?;
     l.cmd("factory", "factory information for this worker", cmd!(cmd_factory))?;
     l.hcmd("eng", "for working on and testing buildomat", cmd!(cmd_eng))?;
 
@@ -372,6 +373,62 @@ async fn cmd_store_put(mut l: Level<Stuff>) -> Result<()> {
         PayloadRes::Ack => Ok(()),
         other => bail!("unexpected response: {other:?}"),
     }
+}
+
+async fn cmd_post(mut l: Level<Stuff>) -> Result<()> {
+    l.context_mut().connect().await?;
+
+    l.cmd(
+        "success",
+        "add a post task running on success",
+        cmd!(cmd_post_success),
+    )?;
+    l.cmd(
+        "failure",
+        "add a post task running on failure",
+        cmd!(cmd_post_failure),
+    )?;
+    l.cmd("always", "add a post task that always runs", cmd!(cmd_post_always))?;
+
+    sel!(l).run().await
+}
+
+async fn cmd_post_success(l: Level<Stuff>) -> Result<()> {
+    post_inner(l, &[PayloadReq::PostSuccess]).await
+}
+
+async fn cmd_post_failure(l: Level<Stuff>) -> Result<()> {
+    post_inner(l, &[PayloadReq::PostFailure]).await
+}
+
+async fn cmd_post_always(l: Level<Stuff>) -> Result<()> {
+    post_inner(l, &[PayloadReq::PostSuccess, PayloadReq::PostFailure]).await
+}
+
+async fn post_inner(
+    mut l: Level<Stuff>,
+    payloads: &[fn(Process) -> PayloadReq],
+) -> Result<()> {
+    l.usage_args(Some("NAME COMMAND [ARGS...]"));
+
+    let a = args!(l);
+
+    for payload in payloads {
+        let req = payload(build_process(&l, a.args())?);
+        match l.context_mut().req(req).await? {
+            PayloadRes::Error(e) => {
+                /*
+                 * This request is purely local to the agent, so an
+                 * error is not something we should retry indefinitely.
+                 */
+                bail!("could not enqueue post task {:?}: {e}", a.args()[0]);
+            }
+            PayloadRes::Ack => {}
+            other => bail!("unexpected response: {other:?}"),
+        }
+    }
+
+    Ok(())
 }
 
 async fn cmd_process(mut l: Level<Stuff>) -> Result<()> {

--- a/agent/src/control/protocol.rs
+++ b/agent/src/control/protocol.rs
@@ -24,19 +24,22 @@ pub struct StoreEntry {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Process {
+    pub name: String,
+    pub cmd: String,
+    pub args: Vec<String>,
+    pub env: Vec<(OsString, OsString)>,
+    pub pwd: OsString,
+    pub uid: u32,
+    pub gid: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum PayloadReq {
     StoreGet(String),
     StorePut(String, String, bool),
     MetadataAddresses,
-    ProcessStart {
-        name: String,
-        cmd: String,
-        args: Vec<String>,
-        env: Vec<(OsString, OsString)>,
-        pwd: String,
-        uid: u32,
-        gid: u32,
-    },
+    ProcessStart(Process),
     FactoryInfo,
 }
 

--- a/agent/src/control/protocol.rs
+++ b/agent/src/control/protocol.rs
@@ -34,12 +34,32 @@ pub struct Process {
     pub gid: u32,
 }
 
+impl Process {
+    pub fn validate(&self) -> Result<(), String> {
+        let name = &self.name;
+
+        if name.len() > 32 {
+            return Err(format!("process name {name:?} is longer than 32"));
+        }
+        if let Some(c) = name
+            .chars()
+            .find(|&c| !c.is_ascii_alphanumeric() && c != '-' && c != '_')
+        {
+            return Err(format!("invalid char {c:?} in process name {name:?}"));
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum PayloadReq {
     StoreGet(String),
     StorePut(String, String, bool),
     MetadataAddresses,
     ProcessStart(Process),
+    PostSuccess(Process),
+    PostFailure(Process),
     FactoryInfo,
 }
 

--- a/agent/src/exec.rs
+++ b/agent/src/exec.rs
@@ -129,7 +129,7 @@ pub enum Activity {
 
 #[derive(Clone)]
 pub enum ActivityBuilder {
-    Task,
+    Task(u32),
     Diag(String),
     Bg(String),
 }
@@ -137,7 +137,7 @@ pub enum ActivityBuilder {
 impl ActivityBuilder {
     fn stdout_stream(&self) -> JobStream {
         match self.clone() {
-            ActivityBuilder::Task => JobStream::Stdout,
+            ActivityBuilder::Task(_) => JobStream::Stdout,
             ActivityBuilder::Diag(_) => JobStream::Stdout,
             ActivityBuilder::Bg(name) => JobStream::BgStdout { name },
         }
@@ -145,7 +145,7 @@ impl ActivityBuilder {
 
     fn stderr_stream(&self) -> JobStream {
         match self.clone() {
-            ActivityBuilder::Task => JobStream::Stderr,
+            ActivityBuilder::Task(_) => JobStream::Stderr,
             ActivityBuilder::Diag(_) => JobStream::Stderr,
             ActivityBuilder::Bg(name) => JobStream::BgStderr { name },
         }
@@ -153,7 +153,7 @@ impl ActivityBuilder {
 
     fn exit_stream(&self) -> JobStream {
         match self.clone() {
-            ActivityBuilder::Task => JobStream::Task,
+            ActivityBuilder::Task(_) => JobStream::Task,
             ActivityBuilder::Diag(name) => JobStream::Diag { name },
             ActivityBuilder::Bg(name) => JobStream::Bg { name },
         }
@@ -161,7 +161,7 @@ impl ActivityBuilder {
 
     fn error_stream(&self) -> JobStream {
         match self.clone() {
-            ActivityBuilder::Task => JobStream::Worker,
+            ActivityBuilder::Task(_) => JobStream::Worker,
             ActivityBuilder::Diag(name) => JobStream::Diag { name },
             ActivityBuilder::Bg(name) => JobStream::Bg { name },
         }
@@ -174,7 +174,7 @@ impl ActivityBuilder {
     fn errmsg(&self, pfx: &str, msg: &str) -> String {
         let mut s = format!("{pfx}: ");
         match self {
-            ActivityBuilder::Task => {}
+            ActivityBuilder::Task(_) => {}
             ActivityBuilder::Diag(_) => {}
             ActivityBuilder::Bg(name) => {
                 s += &format!("background process {name:?}: ")

--- a/agent/src/exec.rs
+++ b/agent/src/exec.rs
@@ -11,13 +11,14 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use anyhow::{anyhow, bail, Result};
+use buildomat_common::JobStream;
 use chrono::prelude::*;
 
 use super::OutputRecord;
 
 fn spawn_reader<T>(
     tx: Sender<Activity>,
-    name: String,
+    name: JobStream,
     stream: Option<T>,
 ) -> Option<std::thread::JoinHandle<()>>
 where
@@ -47,7 +48,10 @@ where
                     let s = String::from_utf8_lossy(&buf);
 
                     if tx
-                        .blocking_send(Activity::msg(&name, s.trim_end()))
+                        .blocking_send(Activity::msg(
+                            name.clone(),
+                            s.trim_end(),
+                        ))
                         .is_err()
                     {
                         /*
@@ -63,7 +67,7 @@ where
                      * server, but don't panic if we cannot.
                      */
                     tx.blocking_send(Activity::msg(
-                        "error",
+                        JobStream::Error,
                         &format!("failed to read {name}: {e:?}"),
                     ))
                     .ok();
@@ -76,7 +80,7 @@ where
 
 #[derive(Debug)]
 pub struct ExitDetails {
-    stream: String,
+    stream: JobStream,
     duration_ms: u64,
     when: DateTime<Utc>,
     code: i32,
@@ -85,7 +89,7 @@ pub struct ExitDetails {
 impl ExitDetails {
     pub(crate) fn to_record(&self) -> OutputRecord {
         OutputRecord {
-            stream: self.stream.to_string(),
+            stream: self.stream.clone(),
             msg: format!(
                 "process exited: duration {} ms, exit code {}",
                 self.duration_ms, self.code
@@ -101,7 +105,7 @@ impl ExitDetails {
 
 #[derive(Clone, Debug)]
 pub struct OutputDetails {
-    stream: String,
+    stream: JobStream,
     msg: String,
     time: DateTime<Utc>,
 }
@@ -109,7 +113,7 @@ pub struct OutputDetails {
 impl OutputDetails {
     pub(crate) fn to_record(&self) -> OutputRecord {
         OutputRecord {
-            stream: self.stream.to_string(),
+            stream: self.stream.clone(),
             msg: self.msg.to_string(),
             time: self.time,
         }
@@ -123,51 +127,76 @@ pub enum Activity {
     Complete,
 }
 
-struct ActivityBuilder {
-    error_stream: String,
-    exit_stream: String,
-    bgproc: Option<String>,
+#[derive(Clone)]
+pub enum ActivityBuilder {
+    Task,
+    Diag(String),
+    Bg(String),
 }
 
 impl ActivityBuilder {
-    fn exit(&self, start: &Instant, end: &Instant, code: i32) -> Activity {
-        Activity::Exit(ExitDetails {
-            stream: self.exit_stream.to_string(),
-            duration_ms: end.duration_since(*start).as_millis() as u64,
-            when: Utc::now(),
-            code,
-        })
-    }
-
-    fn stdout_stream(&self) -> String {
-        if let Some(n) = &self.bgproc {
-            format!("bg.{n}.stdout")
-        } else {
-            "stdout".to_string()
+    fn stdout_stream(&self) -> JobStream {
+        match self.clone() {
+            ActivityBuilder::Task => JobStream::Stdout,
+            ActivityBuilder::Diag(_) => JobStream::Stdout,
+            ActivityBuilder::Bg(name) => JobStream::BgStdout { name },
         }
     }
 
-    fn stderr_stream(&self) -> String {
-        if let Some(n) = &self.bgproc {
-            format!("bg.{n}.stderr")
-        } else {
-            "stderr".to_string()
+    fn stderr_stream(&self) -> JobStream {
+        match self.clone() {
+            ActivityBuilder::Task => JobStream::Stderr,
+            ActivityBuilder::Diag(_) => JobStream::Stderr,
+            ActivityBuilder::Bg(name) => JobStream::BgStderr { name },
         }
+    }
+
+    fn exit_stream(&self) -> JobStream {
+        match self.clone() {
+            ActivityBuilder::Task => JobStream::Task,
+            ActivityBuilder::Diag(name) => JobStream::Diag { name },
+            ActivityBuilder::Bg(name) => JobStream::Bg { name },
+        }
+    }
+
+    fn error_stream(&self) -> JobStream {
+        match self.clone() {
+            ActivityBuilder::Task => JobStream::Worker,
+            ActivityBuilder::Diag(name) => JobStream::Diag { name },
+            ActivityBuilder::Bg(name) => JobStream::Bg { name },
+        }
+    }
+
+    fn is_bg(&self) -> bool {
+        matches!(self, ActivityBuilder::Bg(_))
     }
 
     fn errmsg(&self, pfx: &str, msg: &str) -> String {
         let mut s = format!("{pfx}: ");
-        if let Some(bg) = &self.bgproc {
-            s += &format!("background process {bg:?}: ");
+        match self {
+            ActivityBuilder::Task => {}
+            ActivityBuilder::Diag(_) => {}
+            ActivityBuilder::Bg(name) => {
+                s += &format!("background process {name:?}: ")
+            }
         }
         s += ": ";
         s += msg;
         s
     }
 
+    fn exit(&self, start: &Instant, end: &Instant, code: i32) -> Activity {
+        Activity::Exit(ExitDetails {
+            stream: self.exit_stream(),
+            duration_ms: end.duration_since(*start).as_millis() as u64,
+            when: Utc::now(),
+            code,
+        })
+    }
+
     fn err(&self, msg: &str) -> Activity {
         Activity::Output(OutputDetails {
-            stream: self.error_stream.to_string(),
+            stream: self.error_stream(),
             msg: self.errmsg("exec error", msg),
             time: Utc::now(),
         })
@@ -175,7 +204,7 @@ impl ActivityBuilder {
 
     fn warn(&self, msg: &str) -> Activity {
         Activity::Output(OutputDetails {
-            stream: self.error_stream.to_string(),
+            stream: self.error_stream(),
             msg: self.errmsg("exec warning", msg),
             time: Utc::now(),
         })
@@ -183,9 +212,9 @@ impl ActivityBuilder {
 }
 
 impl Activity {
-    fn msg(stream: &str, msg: &str) -> Activity {
+    fn msg(stream: JobStream, msg: &str) -> Activity {
         Activity::Output(OutputDetails {
-            stream: stream.to_string(),
+            stream,
             msg: msg.to_string(),
             time: Utc::now(),
         })
@@ -229,39 +258,13 @@ pub fn thread_done(
     }
 }
 
-pub fn run_diagnostic(cmd: Command, name: &str) -> Result<Receiver<Activity>> {
+pub fn run(cmd: Command, ab: ActivityBuilder) -> Result<Receiver<Activity>> {
     let (tx, rx) = channel::<Activity>(100);
-
-    run_common(
-        cmd,
-        ActivityBuilder {
-            error_stream: format!("diag.{name}"),
-            exit_stream: format!("diag.{name}"),
-            bgproc: None,
-        },
-        tx,
-    )?;
-
+    run_inner(cmd, ab, tx)?;
     Ok(rx)
 }
 
-pub fn run(cmd: Command) -> Result<Receiver<Activity>> {
-    let (tx, rx) = channel::<Activity>(100);
-
-    run_common(
-        cmd,
-        ActivityBuilder {
-            error_stream: "worker".to_string(),
-            exit_stream: "task".to_string(),
-            bgproc: None,
-        },
-        tx,
-    )?;
-
-    Ok(rx)
-}
-
-fn run_common(
+fn run_inner(
     mut cmd: Command,
     ab: ActivityBuilder,
     tx: Sender<Activity>,
@@ -289,7 +292,7 @@ fn run_common(
                 )
                 .unwrap();
 
-                if ab.bgproc.is_some() {
+                if ab.is_bg() {
                     /*
                      * No further notifications are required for background
                      * processes.
@@ -313,7 +316,7 @@ fn run_common(
                 let stdio_warning = !thread_done(&mut readout, "stdout", until)
                     | !thread_done(&mut readerr, "stderr", until);
 
-                if ab.bgproc.is_some() {
+                if ab.is_bg() {
                     /*
                      * No further notifications are required for background
                      * processes.
@@ -333,7 +336,7 @@ fn run_common(
             }
         };
 
-        assert!(ab.bgproc.is_none());
+        assert!(!ab.is_bg());
 
         if stdio_warning {
             tx.blocking_send(ab.warn(
@@ -449,13 +452,9 @@ impl BackgroundProcesses {
         c.uid(uid);
         c.gid(gid);
 
-        let pid = run_common(
+        let pid = run_inner(
             c,
-            ActivityBuilder {
-                error_stream: format!("bg.{name}"),
-                exit_stream: format!("bg.{name}"),
-                bgproc: Some(name.to_string()),
-            },
+            ActivityBuilder::Bg(name.to_string()),
             self.tx.clone(),
         )
         .map_err(|e| anyhow!("starting background process {name:?}: {e}"))?;
@@ -522,8 +521,7 @@ impl BackgroundProcesses {
         self.rx.close();
         while let Some(a) = self.rx.recv().await {
             if let Activity::Output(o) = &a {
-                if o.stream.ends_with("stdout") || o.stream.ends_with("stderr")
-                {
+                if o.stream.is_output() {
                     lastwords.push(a);
                 }
             }

--- a/agent/src/exec.rs
+++ b/agent/src/exec.rs
@@ -289,14 +289,15 @@ fn run_common(
                 )
                 .unwrap();
 
-                /*
-                 * Only send an exit notification if this is the primary task
-                 * process.
-                 */
-                if ab.bgproc.is_none() {
-                    tx.blocking_send(ab.exit(&start, &end, i32::MAX)).unwrap();
+                if ab.bgproc.is_some() {
+                    /*
+                     * No further notifications are required for background
+                     * processes.
+                     */
+                    return;
                 }
 
+                tx.blocking_send(ab.exit(&start, &end, i32::MAX)).unwrap();
                 false
             }
             Ok(es) => {
@@ -317,6 +318,7 @@ fn run_common(
                      * No further notifications are required for background
                      * processes.
                      */
+                    return;
                 }
 
                 if let Some(sig) = es.signal() {

--- a/agent/src/exec.rs
+++ b/agent/src/exec.rs
@@ -132,6 +132,7 @@ pub enum ActivityBuilder {
     Task(u32),
     Diag(String),
     Bg(String),
+    Post(String),
 }
 
 impl ActivityBuilder {
@@ -140,6 +141,7 @@ impl ActivityBuilder {
             ActivityBuilder::Task(_) => JobStream::Stdout,
             ActivityBuilder::Diag(_) => JobStream::Stdout,
             ActivityBuilder::Bg(name) => JobStream::BgStdout { name },
+            ActivityBuilder::Post(name) => JobStream::PostStdout { name },
         }
     }
 
@@ -148,6 +150,7 @@ impl ActivityBuilder {
             ActivityBuilder::Task(_) => JobStream::Stderr,
             ActivityBuilder::Diag(_) => JobStream::Stderr,
             ActivityBuilder::Bg(name) => JobStream::BgStderr { name },
+            ActivityBuilder::Post(name) => JobStream::PostStderr { name },
         }
     }
 
@@ -156,6 +159,7 @@ impl ActivityBuilder {
             ActivityBuilder::Task(_) => JobStream::Task,
             ActivityBuilder::Diag(name) => JobStream::Diag { name },
             ActivityBuilder::Bg(name) => JobStream::Bg { name },
+            ActivityBuilder::Post(name) => JobStream::Post { name },
         }
     }
 
@@ -164,6 +168,7 @@ impl ActivityBuilder {
             ActivityBuilder::Task(_) => JobStream::Worker,
             ActivityBuilder::Diag(name) => JobStream::Diag { name },
             ActivityBuilder::Bg(name) => JobStream::Bg { name },
+            ActivityBuilder::Post(name) => JobStream::Post { name },
         }
     }
 
@@ -176,6 +181,7 @@ impl ActivityBuilder {
         match self {
             ActivityBuilder::Task(_) => {}
             ActivityBuilder::Diag(_) => {}
+            ActivityBuilder::Post(_) => {}
             ActivityBuilder::Bg(name) => {
                 s += &format!("background process {name:?}: ")
             }

--- a/agent/src/exec.rs
+++ b/agent/src/exec.rs
@@ -3,7 +3,6 @@
  */
 
 use std::collections::HashMap;
-use std::ffi::OsString;
 use std::io::{BufRead, BufReader, Read};
 use std::os::unix::process::{CommandExt, ExitStatusExt};
 use std::process::{Command, Stdio};
@@ -15,6 +14,7 @@ use buildomat_common::JobStream;
 use chrono::prelude::*;
 
 use super::OutputRecord;
+use crate::control::protocol::Process;
 
 fn spawn_reader<T>(
     tx: Sender<Activity>,
@@ -386,23 +386,11 @@ impl BackgroundProcesses {
         BackgroundProcesses { rx, tx, procs: Default::default() }
     }
 
-    pub fn start<'a, A, E>(
-        &mut self,
-        name: &str,
-        cmd: &str,
-        args: A,
-        env: E,
-        pwd: &str,
-        uid: u32,
-        gid: u32,
-    ) -> Result<u32>
-    where
-        A: IntoIterator<Item = &'a String>,
-        E: IntoIterator<Item = &'a (OsString, OsString)>,
-    {
+    pub fn start(&mut self, process: &Process) -> Result<u32> {
         /*
          * Process name must be unique within the task.
          */
+        let name = &process.name;
         if self.procs.contains_key(name) {
             bail!("background process {name:?} is already running");
         }
@@ -423,7 +411,7 @@ impl BackgroundProcesses {
              * child terminates, tearing down the rest of the children:
              */
             c.arg("-l").arg("child");
-            c.arg(cmd);
+            c.arg(&process.cmd);
             c
         };
 
@@ -433,10 +421,10 @@ impl BackgroundProcesses {
              * Regrettably other operating systems do not have contracts.  For
              * now, just start the program.
              */
-            Command::new(cmd)
+            Command::new(&process.cmd)
         };
 
-        for a in args {
+        for a in &process.args {
             c.arg(a);
         }
 
@@ -444,13 +432,13 @@ impl BackgroundProcesses {
          * Use the environment, working directory, and credentials passed to us
          * by the control program, not our own:
          */
-        c.current_dir(pwd);
+        c.current_dir(&process.pwd);
         c.env_clear();
-        for (k, v) in env {
+        for (k, v) in &process.env {
             c.env(k, v);
         }
-        c.uid(uid);
-        c.gid(gid);
+        c.uid(process.uid);
+        c.gid(process.gid);
 
         let pid = run_inner(
             c,

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -60,7 +60,9 @@ mod os_constants {
 }
 use os_constants::*;
 
-use crate::control::protocol::StoreEntry;
+use crate::control::protocol::{Process, StoreEntry};
+
+const QUOTA_POST_TASKS_PER_TYPE: usize = 32;
 
 #[derive(Serialize, Deserialize)]
 struct ConfigFile {
@@ -342,9 +344,9 @@ impl ClientWrap {
                 ActivityBuilder::Task(id) => {
                     AppendJobEntry::TaskEvent(*id, rec)
                 }
-                ActivityBuilder::Diag(_) | ActivityBuilder::Bg(_) => {
-                    AppendJobEntry::JobEvent(rec)
-                }
+                ActivityBuilder::Diag(_)
+                | ActivityBuilder::Bg(_)
+                | ActivityBuilder::Post(_) => AppendJobEntry::JobEvent(rec),
             })
             .await
             .unwrap();
@@ -1020,7 +1022,13 @@ enum Stage {
     Ready,
     Download(mpsc::Receiver<download::Activity>),
     NextTask,
-    Child(mpsc::Receiver<exec::Activity>, ActivityBuilder, Option<bool>),
+    NextPostTask(PostQueue),
+    Child(
+        mpsc::Receiver<exec::Activity>,
+        ActivityBuilder,
+        Option<bool>,
+        NextStage,
+    ),
     Upload(mpsc::Receiver<upload::Activity>),
     StartPreDiagnostics(String),
     PreDiagnostics(mpsc::Receiver<exec::Activity>, Option<bool>),
@@ -1028,6 +1036,22 @@ enum Stage {
     PostDiagnostics(mpsc::Receiver<exec::Activity>, Option<bool>),
     Complete,
     Broken,
+}
+
+/*
+ * Unfortunately we can't add the next stage as a filed of the stage: due to how
+ * stages are used we wouldn't be able to unbox it if we were to add Box<Stage>.
+ */
+#[derive(Clone, Copy)]
+enum NextStage {
+    NextTask,
+    NextPostTask(PostQueue),
+}
+
+#[derive(Clone, Copy)]
+enum PostQueue {
+    Success,
+    Failure,
 }
 
 async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
@@ -1225,6 +1249,8 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
     let mut control = control::server::listen()?;
     let mut creq: Option<control::server::Request> = None;
     let mut bgprocs = exec::BackgroundProcesses::new();
+    let mut post_tasks_success = VecDeque::new();
+    let mut post_tasks_failure = VecDeque::new();
 
     let mut metadata: Option<metadata::FactoryMetadata> = None;
     let mut factory: Option<WorkerPingFactoryInfo> = None;
@@ -1450,10 +1476,20 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                         .unwrap_or_default(),
                 ),
                 PayloadReq::ProcessStart(process) => {
-                    match bgprocs.start(process) {
-                        Ok(_) => PayloadRes::Ack,
-                        Err(e) => PayloadRes::Error(e.to_string()),
+                    if let Err(err) = process.validate() {
+                        PayloadRes::Error(err)
+                    } else {
+                        match bgprocs.start(process) {
+                            Ok(_) => PayloadRes::Ack,
+                            Err(e) => PayloadRes::Error(e.to_string()),
+                        }
                     }
+                }
+                PayloadReq::PostSuccess(process) => {
+                    add_post_task(&mut post_tasks_success, process)
+                }
+                PayloadReq::PostFailure(process) => {
+                    add_post_task(&mut post_tasks_failure, process)
                 }
                 PayloadReq::FactoryInfo => {
                     if let Some(f) = &factory {
@@ -1561,7 +1597,7 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                 if job_failed || tasks.is_empty() {
                     /*
                      * There are no more tasks to complete, so move on to
-                     * uploading outputs.
+                     * running post tasks.
                      */
                     info!(
                         log,
@@ -1569,10 +1605,11 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                         cw.job_id().unwrap(),
                     );
 
-                    stage = Stage::Upload(upload::upload(
-                        cw.clone(),
-                        cw.job.as_ref().unwrap().output_rules.clone(),
-                    ));
+                    stage = Stage::NextPostTask(if job_failed {
+                        PostQueue::Failure
+                    } else {
+                        PostQueue::Success
+                    });
                     continue;
                 }
 
@@ -1639,7 +1676,7 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                 let ab = ActivityBuilder::Task(t.id);
                 match exec::run(cmd, ab.clone()) {
                     Ok(c) => {
-                        stage = Stage::Child(c, ab, None);
+                        stage = Stage::Child(c, ab, None, NextStage::NextTask);
                     }
                     Err(e) => {
                         job_failed = true;
@@ -1663,7 +1700,89 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                     }
                 }
             }
-            Stage::Child(ch, ab, failed) => {
+            Stage::NextPostTask(queue) => {
+                let post_tasks = match queue {
+                    PostQueue::Success => &mut post_tasks_success,
+                    PostQueue::Failure => &mut post_tasks_failure,
+                };
+
+                if post_tasks.is_empty() {
+                    /*
+                     * There are no more tasks to complete, so move on to
+                     * uploading outputs.
+                     */
+                    info!(
+                        log,
+                        "no more post tasks for job {}",
+                        cw.job_id().unwrap()
+                    );
+
+                    stage = Stage::Upload(upload::upload(
+                        cw.clone(),
+                        cw.job.as_ref().unwrap().output_rules.clone(),
+                    ));
+                    continue;
+                }
+
+                let t = post_tasks.pop_front().unwrap();
+
+                /*
+                 * Emit an event that we can use to visually separate tasks
+                 * in the output.
+                 */
+                let msg = format!("starting post task: \"{}\"", t.name);
+                cw.append(OutputRecord::new(
+                    JobStream::Post { name: t.name.clone() },
+                    &msg,
+                ))
+                .await;
+
+                let mut cmd = Command::new(t.cmd);
+                cmd.current_dir(&t.pwd);
+                cmd.args(&t.args);
+                cmd.env_clear();
+                for (k, v) in &t.env {
+                    cmd.env(k, v);
+                }
+                cmd.uid(t.uid);
+                cmd.gid(t.gid);
+
+                let ab = ActivityBuilder::Post(t.name.clone());
+                match exec::run(cmd, ab.clone()) {
+                    Ok(c) => {
+                        stage = Stage::Child(
+                            c,
+                            ab,
+                            None,
+                            NextStage::NextPostTask(*queue),
+                        );
+                    }
+                    Err(e) => {
+                        job_failed = true;
+
+                        /*
+                         * Try to post the error we would have reported
+                         * to the server, but don't try too hard.
+                         */
+                        cw.client
+                            .worker_job_append()
+                            .job(cw.job_id().unwrap())
+                            .body(vec![WorkerAppendJobOrTask {
+                                task: None,
+                                stream: JobStream::Post {
+                                    name: t.name.clone(),
+                                }
+                                .to_string(),
+                                time: Utc::now(),
+                                payload: format!("ERROR: exec: {:?}", e),
+                            }])
+                            .send()
+                            .await
+                            .ok();
+                    }
+                }
+            }
+            Stage::Child(ch, ab, failed, next_stage) => {
                 let a = tokio::select! {
                     _ = pingfreq.tick() => {
                         do_ping = true;
@@ -1712,7 +1831,12 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                             cw.task_complete(*id, failed.unwrap()).await;
                         }
 
-                        stage = Stage::NextTask;
+                        stage = match next_stage {
+                            NextStage::NextTask => Stage::NextTask,
+                            NextStage::NextPostTask(queue) => {
+                                Stage::NextPostTask(*queue)
+                            }
+                        };
                     }
                     None => {
                         for a in bgprocs.killall().await {
@@ -1872,6 +1996,28 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
             }
         }
     }
+}
+
+fn add_post_task(queue: &mut VecDeque<Process>, task: &Process) -> PayloadRes {
+    let name = &task.name;
+
+    if queue.len() >= QUOTA_POST_TASKS_PER_TYPE {
+        return PayloadRes::Error(format!(
+            "cannot register more than {QUOTA_POST_TASKS_PER_TYPE} post tasks"
+        ));
+    }
+    if queue.iter().any(|p| p.name == task.name) {
+        return PayloadRes::Error(format!(
+            "a post task named {name:?} already exists",
+        ));
+    }
+
+    if let Err(err) = task.validate() {
+        return PayloadRes::Error(err);
+    }
+
+    queue.push_back(task.clone());
+    PayloadRes::Ack
 }
 
 #[tokio::main]

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -36,6 +36,7 @@ mod shadow;
 mod upload;
 
 use control::protocol::{FactoryInfo, PayloadReq, PayloadRes};
+use exec::ActivityBuilder;
 
 struct Agent {
     log: Logger,
@@ -92,18 +93,14 @@ impl ConfigFile {
 }
 
 struct OutputRecord {
-    stream: String,
+    stream: JobStream,
     time: DateTime<Utc>,
     msg: String,
 }
 
 impl OutputRecord {
-    fn new(stream: &str, msg: &str) -> OutputRecord {
-        OutputRecord {
-            stream: stream.to_string(),
-            time: Utc::now(),
-            msg: msg.to_string(),
-        }
+    fn new(stream: JobStream, msg: &str) -> OutputRecord {
+        OutputRecord { stream, time: Utc::now(), msg: msg.to_string() }
     }
 }
 
@@ -154,13 +151,13 @@ async fn append_job_worker(
             events.push(match ae {
                 AppendJobEntry::JobEvent(rec) => WorkerAppendJobOrTask {
                     task: None,
-                    stream: rec.stream,
+                    stream: rec.stream.to_string(),
                     payload: rec.msg,
                     time: rec.time,
                 },
                 AppendJobEntry::TaskEvent(task, rec) => WorkerAppendJobOrTask {
                     task: Some(task),
-                    stream: rec.stream,
+                    stream: rec.stream.to_string(),
                     payload: rec.msg,
                     time: rec.time,
                 },
@@ -242,7 +239,7 @@ async fn append_worker_worker(
 
             events.push(match ae {
                 AppendWorkerEntry::WorkerEvent(rec) => WorkerAppend {
-                    stream: rec.stream,
+                    stream: rec.stream.to_string(),
                     payload: rec.msg,
                     time: rec.time,
                 },
@@ -305,8 +302,11 @@ impl ClientWrap {
     }
 
     async fn append_worker_msg(&self, name: &str, msg: &str) {
-        self.append_worker(OutputRecord::new(&format!("diag.{name}"), msg))
-            .await
+        self.append_worker(OutputRecord::new(
+            JobStream::Diag { name: name.into() },
+            msg,
+        ))
+        .await
     }
 
     async fn append_worker(&self, rec: OutputRecord) {
@@ -331,7 +331,7 @@ impl ClientWrap {
     }
 
     async fn append_msg(&self, msg: &str) {
-        self.append(OutputRecord::new("worker", msg)).await;
+        self.append(OutputRecord::new(JobStream::Worker, msg)).await;
     }
 
     async fn append_task(&self, task: &WorkerPingTask, rec: OutputRecord) {
@@ -344,7 +344,7 @@ impl ClientWrap {
     }
 
     async fn append_task_msg(&self, task: &WorkerPingTask, msg: &str) {
-        self.append_task(task, OutputRecord::new("task", msg)).await;
+        self.append_task(task, OutputRecord::new(JobStream::Task, msg)).await;
     }
 
     async fn flush_job_barrier(&self) {
@@ -656,7 +656,7 @@ impl ClientWrap {
         cmd.uid(0);
         cmd.gid(0);
 
-        match exec::run_diagnostic(cmd, name) {
+        match exec::run(cmd, ActivityBuilder::Diag(name.into())) {
             Ok(c) => Ok(c),
             Err(e) => {
                 /*
@@ -666,7 +666,7 @@ impl ClientWrap {
                 self.client
                     .worker_append()
                     .body(vec![WorkerAppend {
-                        stream: "agent".into(),
+                        stream: JobStream::Agent.to_string(),
                         time: Utc::now(),
                         payload: format!("ERROR: diag.{name} exec: {e:?}"),
                     }])
@@ -1633,7 +1633,7 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                 cmd.uid(t.uid);
                 cmd.gid(t.gid);
 
-                match exec::run(cmd) {
+                match exec::run(cmd, ActivityBuilder::Task) {
                     Ok(c) => {
                         stage = Stage::Child(c, t, None);
                     }
@@ -1649,7 +1649,7 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                             .job(cw.job_id().unwrap())
                             .body(vec![WorkerAppendJobOrTask {
                                 task: None,
-                                stream: "agent".into(),
+                                stream: JobStream::Agent.to_string(),
                                 time: Utc::now(),
                                 payload: format!("ERROR: exec: {:?}", e),
                             }])

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -334,17 +334,28 @@ impl ClientWrap {
         self.append(OutputRecord::new(JobStream::Worker, msg)).await;
     }
 
-    async fn append_task(&self, task: &WorkerPingTask, rec: OutputRecord) {
+    async fn append_activity(&self, ab: &ActivityBuilder, rec: OutputRecord) {
         self.tx
             .as_ref()
             .unwrap()
-            .send(AppendJobEntry::TaskEvent(task.id, rec))
+            .send(match ab {
+                ActivityBuilder::Task(id) => {
+                    AppendJobEntry::TaskEvent(*id, rec)
+                }
+                ActivityBuilder::Diag(_) | ActivityBuilder::Bg(_) => {
+                    AppendJobEntry::JobEvent(rec)
+                }
+            })
             .await
             .unwrap();
     }
 
     async fn append_task_msg(&self, task: &WorkerPingTask, msg: &str) {
-        self.append_task(task, OutputRecord::new(JobStream::Task, msg)).await;
+        self.append_activity(
+            &ActivityBuilder::Task(task.id),
+            OutputRecord::new(JobStream::Task, msg),
+        )
+        .await;
     }
 
     async fn flush_job_barrier(&self) {
@@ -360,7 +371,7 @@ impl ClientWrap {
         rx.await.unwrap();
     }
 
-    async fn task_complete(&self, task: &WorkerPingTask, failed: bool) {
+    async fn task_complete(&self, task_id: u32, failed: bool) {
         /*
          * Make sure any previously enqueued event log events have gone out to
          * the server before we complete the task.
@@ -372,7 +383,7 @@ impl ClientWrap {
                 .client
                 .worker_task_complete()
                 .job(self.job_id().unwrap())
-                .task(task.id)
+                .task(task_id)
                 .body_map(|body| body.failed(failed))
                 .send()
                 .await
@@ -1009,7 +1020,7 @@ enum Stage {
     Ready,
     Download(mpsc::Receiver<download::Activity>),
     NextTask,
-    Child(mpsc::Receiver<exec::Activity>, WorkerPingTask, Option<bool>),
+    Child(mpsc::Receiver<exec::Activity>, ActivityBuilder, Option<bool>),
     Upload(mpsc::Receiver<upload::Activity>),
     StartPreDiagnostics(String),
     PreDiagnostics(mpsc::Receiver<exec::Activity>, Option<bool>),
@@ -1625,9 +1636,10 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                 cmd.uid(t.uid);
                 cmd.gid(t.gid);
 
-                match exec::run(cmd, ActivityBuilder::Task) {
+                let ab = ActivityBuilder::Task(t.id);
+                match exec::run(cmd, ab.clone()) {
                     Ok(c) => {
-                        stage = Stage::Child(c, t, None);
+                        stage = Stage::Child(c, ab, None);
                     }
                     Err(e) => {
                         job_failed = true;
@@ -1651,7 +1663,7 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                     }
                 }
             }
-            Stage::Child(ch, t, failed) => {
+            Stage::Child(ch, ab, failed) => {
                 let a = tokio::select! {
                     _ = pingfreq.tick() => {
                         do_ping = true;
@@ -1667,10 +1679,10 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
 
                 match a {
                     Some(exec::Activity::Output(o)) => {
-                        cw.append_task(t, o.to_record()).await;
+                        cw.append_activity(ab, o.to_record()).await;
                     }
                     Some(exec::Activity::Exit(ex)) => {
-                        cw.append_task(t, ex.to_record()).await;
+                        cw.append_activity(ab, ex.to_record()).await;
 
                         /*
                          * Preserve the exit status for when we record task
@@ -1689,21 +1701,23 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                          */
                         for a in bgprocs.killall().await {
                             if let exec::Activity::Output(o) = a {
-                                cw.append_task(t, o.to_record()).await;
+                                cw.append_activity(ab, o.to_record()).await;
                             }
                         }
 
                         /*
                          * Record completion of this task within the job.
                          */
-                        cw.task_complete(t, failed.unwrap()).await;
+                        if let ActivityBuilder::Task(id) = ab {
+                            cw.task_complete(*id, failed.unwrap()).await;
+                        }
 
                         stage = Stage::NextTask;
                     }
                     None => {
                         for a in bgprocs.killall().await {
                             if let exec::Activity::Output(o) = a {
-                                cw.append_task(t, o.to_record()).await;
+                                cw.append_activity(ab, o.to_record()).await;
                             }
                         }
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1438,16 +1438,8 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                         .map(|md| md.addresses().to_vec())
                         .unwrap_or_default(),
                 ),
-                PayloadReq::ProcessStart {
-                    name,
-                    cmd,
-                    args,
-                    env,
-                    pwd,
-                    uid,
-                    gid,
-                } => {
-                    match bgprocs.start(name, cmd, args, env, pwd, *uid, *gid) {
+                PayloadReq::ProcessStart(process) => {
+                    match bgprocs.start(process) {
                         Ok(_) => PayloadRes::Ack,
                         Err(e) => PayloadRes::Error(e.to_string()),
                     }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -644,33 +644,23 @@ async fn poll_job(l: &Level<Stuff>, id: &str, json: bool) -> Result<()> {
     loop {
         match wat.recv().await {
             Some(Ok(buildomat_client::EventOrState::Event(e))) => {
-                if json {
-                    println!("{}", serde_json::to_string(&e)?);
-                } else if e.stream == "stdout" || e.stream == "stderr" {
-                    println!("{}", e.payload);
-                } else if e.stream == "control" {
-                    println!("|=| {}", e.payload);
-                } else if e.stream == "worker" {
-                    println!("|W| {}", e.payload);
-                } else if e.stream == "task" {
-                    println!("|T| {}", e.payload);
-                } else if e.stream == "console" {
-                    println!("|C| {}", e.payload);
-                } else if e.stream == "panic" {
-                    println!("|!| {}", e.payload);
-                } else if e.stream.starts_with("bg.") {
-                    let t = e.stream.split('.').collect::<Vec<_>>();
-                    if t.len() == 3 {
-                        if t[2] == "stdout" || t[2] == "stderr" {
-                            println!("[{}] {}", t[1], e.payload);
-                        } else {
-                            println!("{:?}", e);
-                        }
-                    } else {
-                        println!("{:?}", e);
-                    }
-                } else {
-                    println!("{:?}", e);
+                let stream = JobStream::from_str(&e.stream);
+                let p = &e.payload;
+                match stream {
+                    _ if json => println!("{}", serde_json::to_string(&e)?),
+                    JobStream::BgStderr { name } => println!("[{name}] {p}"),
+                    JobStream::BgStdout { name } => println!("[{name}] {p}"),
+                    JobStream::Console => println!("|C| {p}"),
+                    JobStream::Control => println!("|=| {p}"),
+                    JobStream::Panic => println!("|!| {p}"),
+                    JobStream::Task => println!("|T| {p}"),
+                    JobStream::Worker => println!("|W| {p}"),
+                    JobStream::Stderr | JobStream::Stdout => println!("{p}"),
+                    JobStream::Agent
+                    | JobStream::Bg { .. }
+                    | JobStream::Diag { .. }
+                    | JobStream::Error
+                    | JobStream::Unknown(_) => println!("{e:?}"),
                 }
             }
             Some(Ok(buildomat_client::EventOrState::State(st))) => {

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -653,9 +653,15 @@ async fn poll_job(l: &Level<Stuff>, id: &str, json: bool) -> Result<()> {
                     JobStream::Console => println!("|C| {p}"),
                     JobStream::Control => println!("|=| {p}"),
                     JobStream::Panic => println!("|!| {p}"),
+                    JobStream::Post { .. } => println!("|P| {p}"),
                     JobStream::Task => println!("|T| {p}"),
                     JobStream::Worker => println!("|W| {p}"),
-                    JobStream::Stderr | JobStream::Stdout => println!("{p}"),
+                    JobStream::Stderr
+                    | JobStream::Stdout
+                    | JobStream::PostStderr { .. }
+                    | JobStream::PostStdout { .. } => {
+                        println!("{p}")
+                    }
                     JobStream::Agent
                     | JobStream::Bg { .. }
                     | JobStream::Diag { .. }

--- a/common/src/job_streams.rs
+++ b/common/src/job_streams.rs
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobStream {
+    Agent,
+    Bg { name: String },
+    BgStderr { name: String },
+    BgStdout { name: String },
+    Console,
+    Control,
+    Diag { name: String },
+    Error,
+    Panic,
+    Stderr,
+    Stdout,
+    Task,
+    Worker,
+    Unknown(String),
+}
+
+impl JobStream {
+    pub fn from_str(stream: &str) -> JobStream {
+        let parts = stream.split('.').collect::<Vec<_>>();
+        match parts.as_slice() {
+            ["agent"] => JobStream::Agent,
+            ["bg", name] => JobStream::Bg { name: name.to_string() },
+            ["bg", name, "stdout"] => {
+                JobStream::BgStdout { name: name.to_string() }
+            }
+            ["bg", name, "stderr"] => {
+                JobStream::BgStderr { name: name.to_string() }
+            }
+            ["console"] => JobStream::Console,
+            ["control"] => JobStream::Control,
+            ["diag", name] => JobStream::Diag { name: name.to_string() },
+            ["error"] => JobStream::Error,
+            ["panic"] => JobStream::Panic,
+            ["stderr"] => JobStream::Stderr,
+            ["stdout"] => JobStream::Stdout,
+            ["task"] => JobStream::Task,
+            ["worker"] => JobStream::Worker,
+            _ => JobStream::Unknown(stream.to_string()),
+        }
+    }
+
+    pub fn is_output(&self) -> bool {
+        match self {
+            JobStream::BgStderr { .. }
+            | JobStream::BgStdout { .. }
+            | JobStream::Stderr
+            | JobStream::Stdout => true,
+            JobStream::Agent
+            | JobStream::Bg { .. }
+            | JobStream::Console
+            | JobStream::Control
+            | JobStream::Diag { .. }
+            | JobStream::Error
+            | JobStream::Panic
+            | JobStream::Task
+            | JobStream::Worker
+            | JobStream::Unknown(_) => false,
+        }
+    }
+}
+
+impl std::fmt::Display for JobStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JobStream::Agent => write!(f, "agent"),
+            JobStream::Bg { name } => write!(f, "bg.{name}"),
+            JobStream::BgStderr { name } => write!(f, "bg.{name}.stderr"),
+            JobStream::BgStdout { name } => write!(f, "bg.{name}.stdout"),
+            JobStream::Console => f.write_str("console"),
+            JobStream::Control => f.write_str("control"),
+            JobStream::Diag { name } => write!(f, "diag.{name}"),
+            JobStream::Error => f.write_str("error"),
+            JobStream::Panic => f.write_str("panic"),
+            JobStream::Stderr => f.write_str("stderr"),
+            JobStream::Stdout => f.write_str("stdout"),
+            JobStream::Task => f.write_str("task"),
+            JobStream::Worker => f.write_str("worker"),
+            JobStream::Unknown(s) => f.write_str(s),
+        }
+    }
+}

--- a/common/src/job_streams.rs
+++ b/common/src/job_streams.rs
@@ -13,6 +13,9 @@ pub enum JobStream {
     Diag { name: String },
     Error,
     Panic,
+    Post { name: String },
+    PostStderr { name: String },
+    PostStdout { name: String },
     Stderr,
     Stdout,
     Task,
@@ -37,6 +40,13 @@ impl JobStream {
             ["diag", name] => JobStream::Diag { name: name.to_string() },
             ["error"] => JobStream::Error,
             ["panic"] => JobStream::Panic,
+            ["post", name] => JobStream::Post { name: name.to_string() },
+            ["post", name, "stderr"] => {
+                JobStream::PostStderr { name: name.to_string() }
+            }
+            ["post", name, "stdout"] => {
+                JobStream::PostStdout { name: name.to_string() }
+            }
             ["stderr"] => JobStream::Stderr,
             ["stdout"] => JobStream::Stdout,
             ["task"] => JobStream::Task,
@@ -49,6 +59,8 @@ impl JobStream {
         match self {
             JobStream::BgStderr { .. }
             | JobStream::BgStdout { .. }
+            | JobStream::PostStderr { .. }
+            | JobStream::PostStdout { .. }
             | JobStream::Stderr
             | JobStream::Stdout => true,
             JobStream::Agent
@@ -58,6 +70,7 @@ impl JobStream {
             | JobStream::Diag { .. }
             | JobStream::Error
             | JobStream::Panic
+            | JobStream::Post { .. }
             | JobStream::Task
             | JobStream::Worker
             | JobStream::Unknown(_) => false,
@@ -77,6 +90,9 @@ impl std::fmt::Display for JobStream {
             JobStream::Diag { name } => write!(f, "diag.{name}"),
             JobStream::Error => f.write_str("error"),
             JobStream::Panic => f.write_str("panic"),
+            JobStream::Post { name } => write!(f, "post.{name}"),
+            JobStream::PostStderr { name } => write!(f, "post.{name}.stderr"),
+            JobStream::PostStdout { name } => write!(f, "post.{name}.stdout"),
             JobStream::Stderr => f.write_str("stderr"),
             JobStream::Stdout => f.write_str("stdout"),
             JobStream::Task => f.write_str("task"),

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,8 @@
  * Copyright 2025 Oxide Computer Company
  */
 
+mod job_streams;
+
 use std::io::{IsTerminal, Read};
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
@@ -15,6 +17,8 @@ use regex::Regex;
 use rusty_ulid::Ulid;
 use serde::{Deserialize, Serialize};
 use slog::{o, Drain, Logger};
+
+pub use job_streams::JobStream;
 
 pub fn read_toml<P: AsRef<Path>, T>(n: P) -> Result<T>
 where

--- a/github/server/src/variety/basic.rs
+++ b/github/server/src/variety/basic.rs
@@ -492,7 +492,10 @@ pub(crate) async fn run(
                     }
                     JobStream::Bg { .. }
                     | JobStream::BgStderr { .. }
-                    | JobStream::BgStdout { .. } => {}
+                    | JobStream::BgStdout { .. }
+                    | JobStream::Post { .. }
+                    | JobStream::PostStderr { .. }
+                    | JobStream::PostStdout { .. } => {}
                 }
             }
 

--- a/github/server/src/variety/basic.rs
+++ b/github/server/src/variety/basic.rs
@@ -456,74 +456,43 @@ pub(crate) async fn run(
                     p.event_minseq = ev.seq + 1;
                 }
 
-                let stdio = ev.stream == "stdout" || ev.stream == "stderr";
-                let console = ev.stream == "console";
-                let panic = ev.stream == "panic";
-                let worker = ev.stream == "worker";
-                let bgproc = ev.stream.starts_with("bg.");
-
-                if stdio || console || panic {
-                    /*
-                     * Some commands, like "cargo build --verbose", generate
-                     * exceptionally long output lines, running into the
-                     * thousands of characters.  The long lines present two
-                     * challenges: they are not readily visible without
-                     * horizontal scrolling in the GitHub UI; the maximum status
-                     * message length GitHub will accept is 64KB, and even a
-                     * small number of long lines means our status update will
-                     * not be accepted.
-                     *
-                     * If a line is longer than 90 characters, truncate it.
-                     * Users will still be able to see the full output in our
-                     * detailed view where we get to render the whole page.
-                     */
-                    let mut line = if console {
-                        "|C| "
-                    } else if panic {
-                        "|!|"
-                    } else {
-                        "| "
+                match JobStream::from_str(&ev.stream) {
+                    JobStream::Stderr | JobStream::Stdout => {
+                        let l = format!("| {}", truncate_line(&ev.payload));
+                        p.events_tail.push_back((None, l));
                     }
-                    .to_string();
-
-                    /*
-                     * We support ANSI escapes in the log renderer, which means
-                     * that tools will generate ANSI sequences.  That doesn't
-                     * work in the GitHub renderer, so we need to strip them out
-                     * entirely.
-                     */
-                    let payload = strip_ansi_escapes::strip_str(&ev.payload);
-                    let mut chars = payload.chars();
-
-                    for _ in 0..MAX_LINE_LENGTH {
-                        if let Some(c) = chars.next() {
-                            line.push(c);
-                        } else {
-                            break;
-                        }
+                    JobStream::Console => {
+                        let l = format!("|C| {}", truncate_line(&ev.payload));
+                        p.events_tail.push_back((None, l));
                     }
-                    if chars.next().is_some() {
+                    JobStream::Panic => {
+                        let l = format!("|!| {}", truncate_line(&ev.payload));
+                        p.events_tail.push_back((None, l));
+                    }
+                    JobStream::Worker => {
                         /*
-                         * If any characters remain, the string was truncated.
+                         * A job may produce a large number of files.  We must
+                         * not treat worker output (which is mostly about file
+                         * uploads) as headers.  They must be regular records
+                         * that are discarded as they scroll off the top.
                          */
-                        line.push_str(" [...]");
+                        let line = format!("|W| {}", ev.payload);
+                        p.events_tail.push_back((None, line));
                     }
-
-                    p.events_tail.push_back((None, line));
-                } else if worker {
-                    /*
-                     * A job may produce a large number of files.  We must not
-                     * treat worker output (which is mostly about file uploads
-                     * and so on) as headers.  They must be regular records that
-                     * are discarded as they scroll off the top.
-                     */
-                    let line = format!("|W| {}", ev.payload);
-                    p.events_tail.push_back((None, line));
-                } else if !bgproc {
-                    p.events_tail.push_back((
-                        Some(format!("{}/{:?}", ev.stream, ev.task)),
-                        format!("{}: {}", ev.stream, ev.payload),
-                    ));
+                    JobStream::Agent
+                    | JobStream::Control
+                    | JobStream::Diag { .. }
+                    | JobStream::Error
+                    | JobStream::Task
+                    | JobStream::Unknown(_) => {
+                        p.events_tail.push_back((
+                            Some(format!("{}/{:?}", ev.stream, ev.task)),
+                            format!("{}: {}", ev.stream, ev.payload),
+                        ));
+                    }
+                    JobStream::Bg { .. }
+                    | JobStream::BgStderr { .. }
+                    | JobStream::BgStdout { .. } => {}
                 }
             }
 
@@ -835,6 +804,44 @@ pub(crate) async fn run(
     cr.set_private(p)?;
     db.update_check_run(cr)?;
     Ok(true)
+}
+
+/*
+ * Some commands, like "cargo build --verbose", generate exceptionally long
+ * output lines, running into the thousands of characters.  The long lines
+ * present two challenges: they are not readily visible without horizontal
+ * scrolling in the GitHub UI; the maximum status message length GitHub will
+ * accept is 64KB, and even a small number of long lines means our status
+ * update will not be accepted.
+ *
+ * If a line is longer than 90 characters, truncate it. Users will still be
+ * able to see the full output in our detailed view where we get to render the
+ * whole page.
+ */
+fn truncate_line(payload: &str) -> String {
+    /*
+     * We support ANSI escapes in the log renderer, which means that tools will
+     * generate ANSI sequences.  That doesn't work in the GitHub renderer, so
+     * we need to strip them out entirely.
+     */
+    let payload = strip_ansi_escapes::strip_str(payload);
+    let mut chars = payload.chars();
+
+    let mut line = String::new();
+    for _ in 0..MAX_LINE_LENGTH {
+        if let Some(c) = chars.next() {
+            line.push(c);
+        } else {
+            break;
+        }
+    }
+    if chars.next().is_some() {
+        /*
+         * If any characters remain, the string was truncated.
+         */
+        line.push_str(" [...]");
+    }
+    line
 }
 
 async fn bunyan_to_html(

--- a/jobsh/src/lib.rs
+++ b/jobsh/src/lib.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use buildomat_client::types::JobEvent;
 use buildomat_common::JobStream;
 use chrono::SecondsFormat;
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 pub mod jobfile;
 pub mod variety;
@@ -68,9 +68,15 @@ impl JobEventEx for JobEvent {
             encode_payload(&self.payload),
         );
 
+        let section = if let Some(id) = self.task {
+            EventSection::Task(id)
+        } else {
+            EventSection::None
+        };
+
         EventRow {
-            task: self.task,
             css_class: self.css_class(),
+            section,
             fields: vec![
                 EventField {
                     css_class: "num",
@@ -137,8 +143,8 @@ fn encode_payload(payload: &str) -> Cow<'_, str> {
 
 #[derive(Debug, Serialize)]
 pub struct EventRow {
-    task: Option<u32>,
     css_class: &'static str,
+    section: EventSection,
     fields: Vec<EventField>,
 }
 
@@ -152,6 +158,21 @@ pub struct EventField {
      * This field is a permalink anchor, with this anchor ID:
      */
     anchor: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum EventSection {
+    None,
+    Task(u32),
+}
+
+impl Serialize for EventSection {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            EventSection::None => s.serialize_str("none"),
+            EventSection::Task(idx) => s.serialize_str(&format!("task:{idx}")),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/jobsh/src/lib.rs
+++ b/jobsh/src/lib.rs
@@ -33,6 +33,9 @@ impl JobEventEx for JobEvent {
             JobStream::Console => "s_console",
             JobStream::Control => "s_control",
             JobStream::Panic => "s_panic",
+            JobStream::Post { .. } => "s_post",
+            JobStream::PostStderr { .. } => "s_post_stderr",
+            JobStream::PostStdout { .. } => "s_post_stdout",
             JobStream::Stderr => "s_stderr",
             JobStream::Stdout => "s_stdout",
             JobStream::Task => "s_task",
@@ -70,6 +73,13 @@ impl JobEventEx for JobEvent {
 
         let section = if let Some(id) = self.task {
             EventSection::Task(id)
+        } else if let Some(post) = self.stream.strip_prefix("post.") {
+            EventSection::Post(
+                post.split_once('.')
+                    .map(|(name, _)| name)
+                    .unwrap_or(post)
+                    .into(),
+            )
         } else {
             EventSection::None
         };
@@ -164,6 +174,7 @@ pub struct EventField {
 enum EventSection {
     None,
     Task(u32),
+    Post(String),
 }
 
 impl Serialize for EventSection {
@@ -171,6 +182,7 @@ impl Serialize for EventSection {
         match self {
             EventSection::None => s.serialize_str("none"),
             EventSection::Task(idx) => s.serialize_str(&format!("task:{idx}")),
+            EventSection::Post(n) => s.serialize_str(&format!("post:{n}")),
         }
     }
 }

--- a/jobsh/src/lib.rs
+++ b/jobsh/src/lib.rs
@@ -5,25 +5,19 @@
 use std::borrow::Cow;
 
 use buildomat_client::types::JobEvent;
+use buildomat_common::JobStream;
 use chrono::SecondsFormat;
 use serde::Serialize;
 
 pub mod jobfile;
 pub mod variety;
 
-/*
- * Classes for these streams are defined in the "variety/basic/www/style.css",
- * which we send along with the generated HTML output.
- */
-const CSS_STREAM_CLASSES: &[&str] =
-    &["stdout", "stderr", "task", "worker", "control", "console", "panic"];
-
 pub trait JobEventEx {
     /**
      * Choose a colour (CSS class name) for the stream to which this event
      * belongs.
      */
-    fn css_class(&self) -> String;
+    fn css_class(&self) -> &'static str;
 
     /**
      * Turn a job event into a somewhat abstract object with pre-formatted HTML
@@ -34,15 +28,22 @@ pub trait JobEventEx {
 }
 
 impl JobEventEx for JobEvent {
-    fn css_class(&self) -> String {
-        let s = self.stream.as_str();
-
-        if CSS_STREAM_CLASSES.contains(&s) {
-            format!("s_{s}")
-        } else if s.starts_with("bg.") {
-            "s_bgtask".into()
-        } else {
-            "s_default".into()
+    fn css_class(&self) -> &'static str {
+        match JobStream::from_str(&self.stream) {
+            JobStream::Console => "s_console",
+            JobStream::Control => "s_control",
+            JobStream::Panic => "s_panic",
+            JobStream::Stderr => "s_stderr",
+            JobStream::Stdout => "s_stdout",
+            JobStream::Task => "s_task",
+            JobStream::Worker => "s_worker",
+            JobStream::Bg { .. }
+            | JobStream::BgStderr { .. }
+            | JobStream::BgStdout { .. } => "s_bgtask",
+            JobStream::Agent
+            | JobStream::Error
+            | JobStream::Diag { .. }
+            | JobStream::Unknown(_) => "s_default",
         }
     }
 
@@ -137,7 +138,7 @@ fn encode_payload(payload: &str) -> Cow<'_, str> {
 #[derive(Debug, Serialize)]
 pub struct EventRow {
     task: Option<u32>,
-    css_class: String,
+    css_class: &'static str,
     fields: Vec<EventField>,
 }
 

--- a/jobsh/src/variety/basic.rs
+++ b/jobsh/src/variety/basic.rs
@@ -13,7 +13,7 @@ use futures::future::BoxFuture;
 use hyper::Response;
 use serde::{Deserialize, Serialize};
 
-use crate::JobEventEx;
+use crate::{EventSection, JobEventEx};
 
 /*
  * We can use "deny_unknown_fields" here because the global frontmatter fields
@@ -56,7 +56,7 @@ pub async fn output_table(
 ) -> Result<String> {
     let mut out = "<table id=\"table_output\">\n".to_string();
 
-    let mut last = None;
+    let mut last = EventSection::None;
 
     out += "<tr>\n";
     out += "<td class=\"num\"><span class=\"header\">SEQ</span></td>\n";
@@ -112,10 +112,10 @@ pub async fn output_table(
         let evr = ev.event_row();
 
         /*
-         * If the task has changed, render a full-width blank row in the
+         * If the section has changed, render a full-width blank row in the
          * table:
          */
-        if evr.task != last {
+        if evr.section != last {
             let cols = evr
                 .fields
                 .iter()
@@ -124,7 +124,7 @@ pub async fn output_table(
 
             out += &format!("<tr><td colspan=\"{cols}\">&nbsp;</td></tr>");
         }
-        last = evr.task;
+        last = evr.section;
 
         out += &format!("<tr class=\"{}\">\n", evr.css_class);
 

--- a/variety/basic/www/live.js
+++ b/variety/basic/www/live.js
@@ -4,7 +4,7 @@
 
 var EVT;
 var LOCAL_TIME = %LOCAL_TIME%;
-var LAST_TASK = null;
+var LAST_SECTION = null;
 var LAST_EVENT = null;
 
 /*
@@ -68,9 +68,11 @@ basic_row(ev)
 	}
 
 	/*
-	 * If the task has changed, render a full-width blank row in the table:
+	 * If the section has changed, render a full-width blank row in the table:
 	 */
-	if (evr.task !== LAST_TASK) {
+	if (LAST_SECTION === null) {
+		LAST_SECTION = evr.section;
+	} else if (evr.section !== LAST_SECTION) {
 		let count = 0;
 		for (let i = 0; i < evr.fields.length; i++) {
 			let f = evr.fields[i];
@@ -87,7 +89,7 @@ basic_row(ev)
 		tr.appendChild(td);
 		tbl.appendChild(td);
 
-		LAST_TASK = evr.task;
+		LAST_SECTION = evr.section;
 	}
 
 	let tr = document.createElement("tr");

--- a/variety/basic/www/style.css
+++ b/variety/basic/www/style.css
@@ -76,6 +76,18 @@ tr.s_default {
     background-color: #dddddd;
 }
 
+tr.s_post {
+    background-color: #ffcceb;
+}
+
+tr.s_post_stdout {
+    background-color: #fff0f9;
+}
+
+tr.s_post_stderr {
+    background-color: #ffe5f5;
+}
+
 span.header {
     white-space: pre;
     font-family: monospace;


### PR DESCRIPTION
**Note:** This PR is stacked on top of #102.

---

This PR implements "post tasks", commands that can be executed after all tasks are completed, depending on the outcome of those tasks. Post tasks can be defined at runtime with the new `bmat post` family of commands:

```bash
bmat post success TASK_NAME COMMAND ARG1 ARG2...
bmat post failure TASK_NAME COMMAND ARG1 ARG2...
bmat post always TASK_NAME COMMAND ARG1 ARG2...
```

Whether to execute success or failure post tasks is decided when the last task is finished: if we are executing success post tasks, a failure in one of them will mark the build as failed, but it will *not* start executing failure post tasks.