### PR TITLE
user: implement user factory 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +59,18 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-stream"
@@ -741,6 +759,7 @@ dependencies = [
  "libc",
  "new_mime_guess",
  "rand",
+ "rand_pcg",
  "regex",
  "rusty_ulid",
  "serde",
@@ -896,6 +915,38 @@ dependencies = [
  "toml 0.8.23",
  "usdt",
  "zone",
+]
+
+[[package]]
+name = "buildomat-factory-user"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-compression",
+ "base64 0.22.1",
+ "buildomat-client",
+ "buildomat-common",
+ "buildomat-database",
+ "buildomat-types",
+ "chrono",
+ "expect-test",
+ "getopts",
+ "libc",
+ "rand",
+ "reqwest",
+ "rusty_ulid",
+ "schemars 0.8.22",
+ "sea-query",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-term",
+ "smf",
+ "strum",
+ "tempfile",
+ "tokio",
+ "toml 0.8.23",
+ "usdt",
 ]
 
 [[package]]
@@ -1206,6 +1257,23 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
@@ -1559,6 +1627,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
 name = "dof"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,6 +1813,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "expect-test"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
+dependencies = [
+ "dissimilar",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +1855,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2793,6 +2887,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,6 +3467,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4143,6 +4256,12 @@ checksum = "5584bfb3e0d348139d8210285e39f6d2f8a1902ac06de343e06357d1d763d8e6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "libc",
  "new_mime_guess",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 	"download",
 	"factory/aws",
 	"factory/gimlet",
+	"factory/user",
 	"factory/lab",
 	"factory/propolis",
 	"github/client",
@@ -44,6 +45,7 @@ wrong_self_convention = "allow"
 [workspace.dependencies]
 ansi-to-html = { version = "0.2", features =  [ "lazy-init" ] }
 anyhow = "1"
+async-compression = { version = "0.4", features = ["gzip", "tokio"] }
 aws-config = "1"
 aws-credential-types = "1"
 aws-runtime = "1"
@@ -58,6 +60,7 @@ devinfo = { version = "0.1", features = [ "private" ] }
 dialoguer = { version = "0.12.0", default-features = false }
 dirs-next = "2"
 dropshot = "0.16"
+expect-test = "1"
 futures = "0.3"
 futures-core = "0.3"
 getopts = "0.2"
@@ -80,6 +83,7 @@ percent-encoding = "2.1"
 progenitor = { version = "0.11" }
 progenitor-client = { version = "0.11" }
 rand = "0.10"
+rand_pcg = "0.10"
 regex = "1"
 reqwest = { version = "0.12", features = [ "json", "stream" ] }
 rust-toolchain-file = "0.1"

--- a/agent/smf/agent.xml
+++ b/agent/smf/agent.xml
@@ -11,7 +11,7 @@
         </dependency>
 
         <exec_method name='start' type='method' timeout_seconds='60'
-          exec='/opt/buildomat/lib/start.sh'/>
+          exec='%START_SCRIPT%'/>
         <exec_method name='stop' type='method' timeout_seconds='60'
           exec=':kill'/>
 

--- a/agent/smf/start.sh
+++ b/agent/smf/start.sh
@@ -11,4 +11,4 @@ exec /usr/bin/ctrun \
     -l child \
     -o noorphan,regent \
     \
-    /opt/buildomat/lib/agent run
+    %AGENT_BIN% run

--- a/agent/src/control/mod.rs
+++ b/agent/src/control/mod.rs
@@ -13,14 +13,13 @@ use tokio::{
     net::UnixStream,
 };
 
+use crate::InstallLocation;
 use protocol::{
     Decoder, FactoryInfo, Message, Payload, PayloadReq, PayloadRes,
 };
 
 pub(crate) mod protocol;
 pub(crate) mod server;
-
-pub const SOCKET_PATH: &str = "/var/run/buildomat.sock";
 
 struct Stuff {
     us: Option<UnixStream>,
@@ -30,7 +29,8 @@ struct Stuff {
 
 impl Stuff {
     async fn connect(&mut self) -> Result<()> {
-        self.us = Some(UnixStream::connect(SOCKET_PATH).await?);
+        let loc = InstallLocation::detect()?;
+        self.us = Some(UnixStream::connect(loc.control_sock()).await?);
         self.dec = Some(Decoder::new());
         Ok(())
     }

--- a/agent/src/control/server.rs
+++ b/agent/src/control/server.rs
@@ -15,10 +15,8 @@ use tokio::{
     },
 };
 
-use super::{
-    protocol::{Decoder, Message, Payload, PayloadReq, PayloadRes},
-    SOCKET_PATH,
-};
+use super::protocol::{Decoder, Message, Payload, PayloadReq, PayloadRes};
+use crate::InstallLocation;
 
 #[derive(Debug)]
 pub struct Request {
@@ -48,19 +46,21 @@ impl Request {
 }
 
 pub fn listen() -> Result<Receiver<Request>> {
+    let loc = InstallLocation::detect()?;
+
     /*
      * Create the UNIX socket that the control program will use to contact the
      * agent.
      */
-    std::fs::remove_file(SOCKET_PATH).ok();
-    let ul = UnixListener::bind(SOCKET_PATH)?;
+    std::fs::remove_file(loc.control_sock()).ok();
+    let ul = UnixListener::bind(loc.control_sock())?;
 
     /*
      * Allow everyone to connect:
      */
-    let mut perm = std::fs::metadata(SOCKET_PATH)?.permissions();
+    let mut perm = std::fs::metadata(loc.control_sock())?.permissions();
     perm.set_mode(0o777);
-    std::fs::set_permissions(SOCKET_PATH, perm)?;
+    std::fs::set_permissions(loc.control_sock(), perm)?;
 
     /*
      * Create channel to hand requests back to the main loop.

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1032,8 +1032,10 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
     l.usage_args(Some("BASEURL BOOTSTRAP_TOKEN"));
     l.optopt("N", "", "set nodename of machine", "NODENAME");
     l.optmulti("e", "", "add environment variables", "KEY=VALUE");
+    l.optflag("", "no-service", "avoid creating the system service");
 
     let a = args!(l);
+    let start_service = !a.opts().opt_present("no-service");
     let log = l.context().log.clone();
 
     /*
@@ -1093,7 +1095,7 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
     std::fs::copy(&exe, &cprog)?;
     make_executable(&cprog)?;
 
-    if cfg!(target_os = "illumos") {
+    if cfg!(target_os = "illumos") && start_service {
         /*
          * Copy SMF method script and manifest into place.
          */
@@ -1138,7 +1140,7 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
             Ok(o) => bail!("svccfg import failure: {:?}", o),
             Err(e) => bail!("could not execute svccfg import: {:?}", e),
         }
-    } else if cfg!(target_os = "linux") {
+    } else if cfg!(target_os = "linux") && start_service {
         /*
          * Create the input directory.
          */

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -2,7 +2,7 @@
  * Copyright 2024 Oxide Computer Company
  */
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{ErrorKind::NotFound, Write};
@@ -13,7 +13,7 @@ use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use chrono::prelude::*;
 use futures::StreamExt;
 use hiercmd::prelude::*;
@@ -61,11 +61,12 @@ use os_constants::*;
 
 use crate::control::protocol::StoreEntry;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 struct ConfigFile {
     baseurl: String,
     bootstrap: String,
     token: String,
+    env: HashMap<String, String>,
 }
 
 impl ConfigFile {
@@ -87,7 +88,14 @@ impl ConfigFile {
             rx,
         ));
 
-        ClientWrap { log, client, job: None, tx: None, worker_tx }
+        ClientWrap {
+            log,
+            config: self.clone(),
+            client,
+            job: None,
+            tx: None,
+            worker_tx,
+        }
     }
 }
 
@@ -277,6 +285,7 @@ async fn append_worker_worker(
 #[derive(Clone)]
 pub(crate) struct ClientWrap {
     log: Logger,
+    config: ConfigFile,
     client: buildomat_client::Client,
     job: Option<Arc<WorkerPingJob>>,
     tx: Option<mpsc::Sender<AppendJobEntry>>,
@@ -648,6 +657,13 @@ impl ClientWrap {
         );
         cmd.env("LANG", "en_US.UTF-8");
         cmd.env("LC_ALL", "en_US.UTF-8");
+
+        /*
+         * Add variables configured at agent installation time.
+         */
+        for (k, v) in &self.config.env {
+            cmd.env(k, v);
+        }
 
         /*
          * Run the diagnostic script as root:
@@ -1022,6 +1038,7 @@ enum Stage {
 async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
     l.usage_args(Some("BASEURL BOOTSTRAP_TOKEN"));
     l.optopt("N", "", "set nodename of machine", "NODENAME");
+    l.optmulti("e", "", "add environment variables", "KEY=VALUE");
 
     let a = args!(l);
     let log = l.context().log.clone();
@@ -1029,6 +1046,20 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
     if a.args().len() < 2 {
         bad_args!(l, "specify base URL and bootstrap token value");
     }
+
+    /*
+     * Parse "-e KEY=VALUE" into keys and values.
+     */
+    let env = a
+        .opts()
+        .opt_strs("e")
+        .into_iter()
+        .map(|v| {
+            v.split_once('=')
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .ok_or_else(|| anyhow!("invalid flag: -e {v}"))
+        })
+        .collect::<Result<HashMap<_, _>, _>>()?;
 
     /*
      * The server will have provided these parameters in the userscript
@@ -1048,7 +1079,7 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
      */
     make_dirs_for(CONFIG_PATH)?;
     rmfile(CONFIG_PATH)?;
-    let cf = ConfigFile { baseurl, bootstrap, token: genkey(64) };
+    let cf = ConfigFile { baseurl, bootstrap, token: genkey(64), env };
     store(CONFIG_PATH, &cf)?;
 
     /*
@@ -1615,6 +1646,13 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                     cmd.env("LC_ALL", "en_US.UTF-8");
                     cmd.env("BUILDOMAT_JOB_ID", cw.job_id().unwrap());
                     cmd.env("BUILDOMAT_TASK_ID", t.id.to_string());
+
+                    /*
+                     * Add variables configured at agent installation time.
+                     */
+                    for (k, v) in &cf.env {
+                        cmd.env(k, v);
+                    }
                 }
                 for (k, v) in t.env.iter() {
                     /*

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1043,10 +1043,6 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
     let a = args!(l);
     let log = l.context().log.clone();
 
-    if a.args().len() < 2 {
-        bad_args!(l, "specify base URL and bootstrap token value");
-    }
-
     /*
      * Parse "-e KEY=VALUE" into keys and values.
      */
@@ -1060,6 +1056,10 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
                 .ok_or_else(|| anyhow!("invalid flag: -e {v}"))
         })
         .collect::<Result<HashMap<_, _>, _>>()?;
+
+    if a.args().len() != 2 {
+        bad_args!(l, "specify base URL and bootstrap token value");
+    }
 
     /*
      * The server will have provided these parameters in the userscript

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1218,105 +1218,115 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
         }
     }
 
-    if cfg!(target_os = "illumos") && start_service {
-        /*
-         * Copy SMF method script and manifest into place.
-         */
-        let script = include_str!("../smf/start.sh").replace(
-            "%AGENT_BIN%",
-            location
-                .agent_bin()
-                .to_str()
-                .ok_or_else(|| anyhow!("non-UTF-8 path"))?,
-        );
-        make_dirs_for(location.illumos_start_script())?;
-        rmfile(location.illumos_start_script())?;
-        write_text(location.illumos_start_script(), &script)?;
-        make_executable(location.illumos_start_script())?;
+    if start_service {
+        if cfg!(target_os = "illumos") {
+            /*
+             * Copy SMF method script and manifest into place.
+             */
+            let script = include_str!("../smf/start.sh").replace(
+                "%AGENT_BIN%",
+                location
+                    .agent_bin()
+                    .to_str()
+                    .ok_or_else(|| anyhow!("non-UTF-8 path"))?,
+            );
+            make_dirs_for(location.illumos_start_script())?;
+            rmfile(location.illumos_start_script())?;
+            write_text(location.illumos_start_script(), &script)?;
+            make_executable(location.illumos_start_script())?;
 
-        let manifest = include_str!("../smf/agent.xml").replace(
-            "%START_SCRIPT%",
-            location
-                .illumos_start_script()
-                .to_str()
-                .ok_or_else(|| anyhow!("non-UTF-8 path"))?,
-        );
-        rmfile(ILLUMOS_MANIFEST)?;
-        write_text(ILLUMOS_MANIFEST, &manifest)?;
+            let manifest = include_str!("../smf/agent.xml").replace(
+                "%START_SCRIPT%",
+                location
+                    .illumos_start_script()
+                    .to_str()
+                    .ok_or_else(|| anyhow!("non-UTF-8 path"))?,
+            );
+            rmfile(ILLUMOS_MANIFEST)?;
+            write_text(ILLUMOS_MANIFEST, &manifest)?;
 
-        /*
-         * Create the input directory.
-         */
-        let status = Command::new("/sbin/zfs")
-            .arg("create")
-            .arg("-o")
-            .arg(format!("mountpoint={INPUT_PATH}"))
-            .arg(ILLUMOS_INPUT_DATASET)
-            .env_clear()
-            .current_dir("/")
-            .status();
-        match status {
-            Ok(o) if o.success() => (),
-            Ok(o) => bail!("zfs create failure: {:?}", o),
-            Err(e) => bail!("could not execute zfs create: {:?}", e),
+            /*
+             * Create the input directory.
+             */
+            let status = Command::new("/sbin/zfs")
+                .arg("create")
+                .arg("-o")
+                .arg(format!("mountpoint={INPUT_PATH}"))
+                .arg(ILLUMOS_INPUT_DATASET)
+                .env_clear()
+                .current_dir("/")
+                .status();
+            match status {
+                Ok(o) if o.success() => (),
+                Ok(o) => bail!("zfs create failure: {:?}", o),
+                Err(e) => bail!("could not execute zfs create: {:?}", e),
+            }
+
+            /*
+             * Import SMF service.
+             */
+            let status = Command::new("/usr/sbin/svccfg")
+                .arg("import")
+                .arg(ILLUMOS_MANIFEST)
+                .env_clear()
+                .current_dir("/")
+                .status();
+            match status {
+                Ok(o) if o.success() => (),
+                Ok(o) => bail!("svccfg import failure: {:?}", o),
+                Err(e) => bail!("could not execute svccfg import: {:?}", e),
+            }
+        } else if cfg!(target_os = "linux") {
+            /*
+             * Create the input directory.
+             */
+            std::fs::create_dir_all(INPUT_PATH)?;
+
+            /*
+             * Write a systemd unit file for the agent service.
+             */
+            let unit = include_str!("../systemd/agent.service");
+            make_dirs_for(LINUX_UNIT)?;
+            rmfile(LINUX_UNIT)?;
+            write_text(LINUX_UNIT, unit)?;
+
+            /*
+             * Ask systemd to load the unit file we just wrote.
+             */
+            let status = Command::new("/bin/systemctl")
+                .arg("daemon-reload")
+                .env_clear()
+                .current_dir("/")
+                .status();
+            match status {
+                Ok(o) if o.success() => {}
+                Ok(o) => bail!("systemd reload failure: {:?}", o),
+                Err(e) => bail!("could not execute daemon-reload: {:?}", e),
+            }
+
+            /*
+             * Attempt to start the service:
+             */
+            let status = Command::new("/bin/systemctl")
+                .arg("start")
+                .arg("buildomat-agent.service")
+                .env_clear()
+                .current_dir("/")
+                .status();
+            match status {
+                Ok(o) if o.success() => {}
+                Ok(o) => bail!("systemd start failure: {:?}", o),
+                Err(e) => bail!("could not execute systemctl: {:?}", e),
+            }
+        } else {
+            bail!("agent doesn't know how to start a service on this OS");
         }
-
+    } else {
         /*
-         * Import SMF service.
+         * If we are running without a service, fork a child to run the agent
+         * immediately rather than using the service manager.
          */
-        let status = Command::new("/usr/sbin/svccfg")
-            .arg("import")
-            .arg(ILLUMOS_MANIFEST)
-            .env_clear()
-            .current_dir("/")
-            .status();
-        match status {
-            Ok(o) if o.success() => (),
-            Ok(o) => bail!("svccfg import failure: {:?}", o),
-            Err(e) => bail!("could not execute svccfg import: {:?}", e),
-        }
-    } else if cfg!(target_os = "linux") && start_service {
-        /*
-         * Create the input directory.
-         */
-        std::fs::create_dir_all(INPUT_PATH)?;
-
-        /*
-         * Write a systemd unit file for the agent service.
-         */
-        let unit = include_str!("../systemd/agent.service");
-        make_dirs_for(LINUX_UNIT)?;
-        rmfile(LINUX_UNIT)?;
-        write_text(LINUX_UNIT, unit)?;
-
-        /*
-         * Ask systemd to load the unit file we just wrote.
-         */
-        let status = Command::new("/bin/systemctl")
-            .arg("daemon-reload")
-            .env_clear()
-            .current_dir("/")
-            .status();
-        match status {
-            Ok(o) if o.success() => {}
-            Ok(o) => bail!("systemd reload failure: {:?}", o),
-            Err(e) => bail!("could not execute daemon-reload: {:?}", e),
-        }
-
-        /*
-         * Attempt to start the service:
-         */
-        let status = Command::new("/bin/systemctl")
-            .arg("start")
-            .arg("buildomat-agent.service")
-            .env_clear()
-            .current_dir("/")
-            .status();
-        match status {
-            Ok(o) if o.success() => {}
-            Ok(o) => bail!("systemd start failure: {:?}", o),
-            Err(e) => bail!("could not execute systemctl: {:?}", e),
-        }
+        let _child = Command::new(location.agent_bin()).arg("run").spawn()?;
     }
 
     Ok(())

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -26,6 +26,7 @@ use tokio::sync::oneshot;
 use tokio::time::MissedTickBehavior;
 
 use buildomat_client::types::*;
+use buildomat_common::unix::{Passwd, Uid};
 use buildomat_common::*;
 use buildomat_types::*;
 
@@ -633,6 +634,15 @@ impl ClientWrap {
 
         let mut cmd = Command::new("/bin/bash");
         cmd.arg(&s);
+        cmd.current_dir("/");
+
+        /*
+         * Run the diagnostic script as root:
+         */
+        let passwd = Passwd::by_name("root")?
+            .ok_or_else(|| anyhow!("missing root user"))?;
+        cmd.uid(passwd.uid.0);
+        cmd.gid(passwd.gid.0);
 
         /*
          * The diagnostic task should have a pristine and reproducible
@@ -640,9 +650,13 @@ impl ClientWrap {
          */
         cmd.env_clear();
 
-        cmd.env("HOME", "/root");
-        cmd.env("USER", "root");
-        cmd.env("LOGNAME", "root");
+        if let Some(dir) = &passwd.dir {
+            cmd.env("HOME", dir);
+        }
+        if let Some(name) = &passwd.name {
+            cmd.env("USER", name);
+            cmd.env("LOGNAME", name);
+        }
         cmd.env("TZ", "UTC");
         cmd.env(
             "PATH",
@@ -657,13 +671,6 @@ impl ClientWrap {
         for (k, v) in &self.config.env {
             cmd.env(k, v);
         }
-
-        /*
-         * Run the diagnostic script as root:
-         */
-        cmd.current_dir("/");
-        cmd.uid(0);
-        cmd.gid(0);
 
         match exec::run_diagnostic(cmd, name) {
             Ok(c) => Ok(c),
@@ -1613,6 +1620,18 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                 cmd.arg(&s);
 
                 /*
+                 * Each task may be expected to run under a different user
+                 * account or with a different working directory.
+                 */
+                cmd.current_dir(&t.workdir);
+                cmd.uid(t.uid);
+                cmd.gid(t.gid);
+
+                let passwd = Passwd::by_uid(Uid(t.uid))?.ok_or_else(|| {
+                    anyhow!("no user on the system with uid {}", t.uid)
+                })?;
+
+                /*
                  * The user task should have a pristine and reproducible
                  * environment that does not leak in artefacts of the
                  * agent.
@@ -1622,11 +1641,14 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                     /*
                      * Absent a request for an entirely clean slate, we
                      * set a few specific environment variables.
-                     * XXX HOME/USER/LOGNAME should probably respect "uid"
                      */
-                    cmd.env("HOME", "/root");
-                    cmd.env("USER", "root");
-                    cmd.env("LOGNAME", "root");
+                    if let Some(name) = &passwd.name {
+                        cmd.env("USER", name);
+                        cmd.env("LOGNAME", name);
+                    }
+                    if let Some(dir) = &passwd.dir {
+                        cmd.env("HOME", dir);
+                    }
                     cmd.env("TZ", "UTC");
                     cmd.env(
                         "PATH",
@@ -1653,14 +1675,6 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                      */
                     cmd.env(k, v);
                 }
-
-                /*
-                 * Each task may be expected to run under a different user
-                 * account or with a different working directory.
-                 */
-                cmd.current_dir(&t.workdir);
-                cmd.uid(t.uid);
-                cmd.gid(t.gid);
 
                 match exec::run(cmd) {
                     Ok(c) => {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -36,24 +36,108 @@ mod exec;
 mod shadow;
 mod upload;
 
-use control::protocol::{FactoryInfo, PayloadReq, PayloadRes};
+use control::protocol::{FactoryInfo, PayloadReq, PayloadRes, StoreEntry};
+use std::ffi::OsString;
 
 struct Agent {
     log: Logger,
 }
 
-const CONFIG_PATH: &str = "/opt/buildomat/etc/agent.json";
-const JOB_PATH: &str = "/opt/buildomat/etc/job.json";
-const AGENT: &str = "/opt/buildomat/lib/agent";
+const PATH: &[&str] = &[
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+    #[cfg(target_os = "illumos")]
+    "/opt/ooce/bin",
+    #[cfg(target_os = "illumos")]
+    "/opt/ooce/sbin",
+];
+
 const INPUT_PATH: &str = "/input";
 const CONTROL_PROGRAM: &str = "bmat";
 const SHADOW: &str = "/etc/shadow";
-const ILLUMOS_METHOD: &str = "/opt/buildomat/lib/start.sh";
 const ILLUMOS_MANIFEST: &str = "/var/svc/manifest/site/buildomat-agent.xml";
 const ILLUMOS_INPUT_DATASET: &str = "rpool/input";
 const LINUX_UNIT: &str = "/etc/systemd/system/buildomat-agent.service";
 
-use crate::control::protocol::StoreEntry;
+#[derive(Debug, Clone, Copy)]
+enum InstallLocation {
+    System,
+    VarRun,
+}
+
+impl InstallLocation {
+    fn detect() -> Result<Self> {
+        for loc in [InstallLocation::VarRun, InstallLocation::System] {
+            if loc.agent_config().is_file() {
+                return Ok(loc);
+            }
+        }
+        bail!("cannot find an agent installation");
+    }
+
+    fn agent_config(&self) -> &Path {
+        Path::new(match self {
+            InstallLocation::System => "/opt/buildomat/etc/agent.json",
+            InstallLocation::VarRun => "/var/run/buildomat/agent/agent.json",
+        })
+    }
+
+    fn agent_bin(&self) -> &Path {
+        Path::new(match self {
+            InstallLocation::System => "/opt/buildomat/lib/agent",
+            InstallLocation::VarRun => "/var/run/buildomat/agent/agent",
+        })
+    }
+
+    fn control_bin(&self) -> &Path {
+        Path::new(match self {
+            InstallLocation::System => "/usr/bin/bmat",
+            InstallLocation::VarRun => "/var/run/buildomat/agent/bin/bmat",
+        })
+    }
+
+    fn control_sock(&self) -> &Path {
+        Path::new(match self {
+            InstallLocation::System => "/var/run/buildomat.sock",
+            InstallLocation::VarRun => "/var/run/buildomat/agent/agent.sock",
+        })
+    }
+
+    fn illumos_start_script(&self) -> &Path {
+        Path::new(match self {
+            InstallLocation::System => "/opt/buildomat/lib/start.sh",
+            InstallLocation::VarRun => "/var/run/buildomat/agent/start.sh",
+        })
+    }
+
+    fn job_config(&self) -> &Path {
+        Path::new(match self {
+            InstallLocation::System => "/opt/buildomat/etc/job.json",
+            InstallLocation::VarRun => "/var/run/buildomat/agent/job.json",
+        })
+    }
+
+    fn system_path(&self) -> Result<OsString> {
+        let mut path = PATH.to_vec();
+
+        /*
+         * Make sure the "bmat" CLI is in the path.
+         */
+        let control_dir = self
+            .control_bin()
+            .parent()
+            .unwrap()
+            .to_str()
+            .ok_or_else(|| anyhow!("non-UTF-8 path: {path:?}"))?;
+        if !path.contains(&control_dir) {
+            path.insert(0, control_dir);
+        }
+
+        Ok(std::env::join_paths(&path)?)
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone)]
 struct ConfigFile {
@@ -65,7 +149,7 @@ struct ConfigFile {
 }
 
 impl ConfigFile {
-    fn make_client(&self, log: Logger) -> ClientWrap {
+    fn make_client(&self, log: Logger, loc: InstallLocation) -> ClientWrap {
         let client = buildomat_client::ClientBuilder::new(&self.baseurl)
             .bearer_token(&self.token)
             .build()
@@ -85,6 +169,7 @@ impl ConfigFile {
 
         ClientWrap {
             log,
+            loc,
             config: self.clone(),
             client,
             job: None,
@@ -280,6 +365,7 @@ async fn append_worker_worker(
 #[derive(Clone)]
 pub(crate) struct ClientWrap {
     log: Logger,
+    loc: InstallLocation,
     config: ConfigFile,
     client: buildomat_client::Client,
     job: Option<Arc<WorkerPingJob>>,
@@ -667,10 +753,7 @@ impl ClientWrap {
             bail!("user {} doesn't have a name", passwd.uid.0);
         }
         cmd.env("TZ", "UTC");
-        cmd.env(
-            "PATH",
-            "/usr/bin:/bin:/usr/sbin:/sbin:/opt/ooce/bin:/opt/ooce/sbin",
-        );
+        cmd.env("PATH", self.loc.system_path()?);
         cmd.env("LANG", "en_US.UTF-8");
         cmd.env("LC_ALL", "en_US.UTF-8");
 
@@ -1050,11 +1133,18 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
     l.optmulti("e", "", "add environment variables", "KEY=VALUE");
     l.optflag("", "no-service", "avoid creating the system service");
     l.optflag("", "no-setuid", "prevent the agent from changing users");
+    l.optflag("", "use-var-run", "store agent state in /var/run");
 
     let a = args!(l);
     let start_service = !a.opts().opt_present("no-service");
     let setuid = !a.opts().opt_present("no-setuid");
     let log = l.context().log.clone();
+
+    let location = if a.opts().opt_present("use-var-run") {
+        InstallLocation::VarRun
+    } else {
+        InstallLocation::System
+    };
 
     /*
      * Parse "-e KEY=VALUE" into keys and values.
@@ -1088,44 +1178,71 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
     }
 
     /*
-     * Write /opt/buildomat/etc/agent.json with this configuration.
+     * Write the configuration.
      */
-    make_dirs_for(CONFIG_PATH)?;
-    rmfile(CONFIG_PATH)?;
+    make_dirs_for(location.agent_config())?;
+    rmfile(location.agent_config())?;
     let cf = ConfigFile { baseurl, bootstrap, token: genkey(64), setuid, env };
-    store(CONFIG_PATH, &cf)?;
+    store(location.agent_config(), &cf)?;
 
     /*
      * Copy the agent binary into a permanent home.
      */
     let exe = env::current_exe()?;
-    make_dirs_for(AGENT)?;
-    rmfile(AGENT)?;
-    std::fs::copy(&exe, AGENT)?;
-    make_executable(AGENT)?;
+    make_dirs_for(location.agent_bin())?;
+    rmfile(location.agent_bin())?;
+    std::fs::copy(&exe, location.agent_bin())?;
+    make_executable(location.agent_bin())?;
 
     /*
      * Install the agent binary with the control program name in a location in
      * the default PATH so that job programs can find it.
      */
-    let cprog = format!("/usr/bin/{CONTROL_PROGRAM}");
-    rmfile(&cprog)?;
-    std::fs::copy(&exe, &cprog)?;
-    make_executable(&cprog)?;
+    make_dirs_for(location.control_bin())?;
+    rmfile(location.control_bin())?;
+    std::fs::copy(&exe, location.control_bin())?;
+    make_executable(location.control_bin())?;
+
+    /*
+     * Ubuntu 18.04 had a genuine pre-war separate /bin directory!
+     */
+    if cfg!(target_os = "linux") {
+        if let InstallLocation::System = location {
+            let binmd = std::fs::symlink_metadata("/bin")?;
+            if binmd.is_dir() {
+                std::os::unix::fs::symlink(
+                    format!("../usr/bin/{CONTROL_PROGRAM}"),
+                    format!("/bin/{CONTROL_PROGRAM}"),
+                )?;
+            }
+        }
+    }
 
     if cfg!(target_os = "illumos") && start_service {
         /*
          * Copy SMF method script and manifest into place.
          */
-        let method = include_str!("../smf/start.sh");
-        make_dirs_for(ILLUMOS_METHOD)?;
-        rmfile(ILLUMOS_METHOD)?;
-        write_text(ILLUMOS_METHOD, method)?;
-        make_executable(ILLUMOS_METHOD)?;
+        let script = include_str!("../smf/start.sh").replace(
+            "%AGENT_BIN%",
+            location
+                .agent_bin()
+                .to_str()
+                .ok_or_else(|| anyhow!("non-UTF-8 path"))?,
+        );
+        make_dirs_for(location.illumos_start_script())?;
+        rmfile(location.illumos_start_script())?;
+        write_text(location.illumos_start_script(), &script)?;
+        make_executable(location.illumos_start_script())?;
 
-        let manifest = include_str!("../smf/agent.xml");
+        let manifest = include_str!("../smf/agent.xml").replace(
+            "%START_SCRIPT%",
+            location
+                .illumos_start_script()
+                .to_str()
+                .ok_or_else(|| anyhow!("non-UTF-8 path"))?,
+        );
         rmfile(ILLUMOS_MANIFEST)?;
-        write_text(ILLUMOS_MANIFEST, manifest)?;
+        write_text(ILLUMOS_MANIFEST, &manifest)?;
 
         /*
          * Create the input directory.
@@ -1200,17 +1317,6 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
             Ok(o) => bail!("systemd start failure: {:?}", o),
             Err(e) => bail!("could not execute systemctl: {:?}", e),
         }
-
-        /*
-         * Ubuntu 18.04 had a genuine pre-war separate /bin directory!
-         */
-        let binmd = std::fs::symlink_metadata("/bin")?;
-        if binmd.is_dir() {
-            std::os::unix::fs::symlink(
-                format!("../usr/bin/{CONTROL_PROGRAM}"),
-                format!("/bin/{CONTROL_PROGRAM}"),
-            )?;
-        }
     }
 
     Ok(())
@@ -1219,11 +1325,12 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
 async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
     no_args!(l);
 
-    let cf = load::<_, ConfigFile>(CONFIG_PATH)?;
+    let loc = InstallLocation::detect()?;
+    let cf = load::<_, ConfigFile>(loc.agent_config())?;
     let log = l.context().log.clone();
 
     info!(log, "agent starting"; "baseurl" => &cf.baseurl);
-    let mut cw = cf.make_client(log.clone());
+    let mut cw = cf.make_client(log.clone(), loc);
 
     let res = loop {
         let res = cw
@@ -1272,7 +1379,7 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
      * any evidence that we've done this before, we must report it to the
      * central server and do nothing else.
      */
-    if PathBuf::from(JOB_PATH).try_exists()? {
+    if PathBuf::from(loc.job_config()).try_exists()? {
         error!(log, "found previously assigned job; reporting failure");
 
         /*
@@ -1410,7 +1517,7 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                                     .create_new(true)
                                     .create(false)
                                     .write(true)
-                                    .open(JOB_PATH)?;
+                                    .open(loc.job_config())?;
                                 jf.write_all(&diag)?;
                                 jf.flush()?;
                                 jf.sync_all()?;
@@ -1675,11 +1782,7 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                         bail!("user {} doesn't have a name", passwd.uid.0);
                     }
                     cmd.env("TZ", "UTC");
-                    cmd.env(
-                        "PATH",
-                        "/usr/bin:/bin:/usr/sbin:/sbin:\
-                            /opt/ooce/bin:/opt/ooce/sbin",
-                    );
+                    cmd.env("PATH", loc.system_path()?);
                     cmd.env("LANG", "en_US.UTF-8");
                     cmd.env("LC_ALL", "en_US.UTF-8");
                     cmd.env("BUILDOMAT_JOB_ID", cw.job_id().unwrap());

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -60,6 +60,7 @@ struct ConfigFile {
     baseurl: String,
     bootstrap: String,
     token: String,
+    setuid: bool,
     env: HashMap<String, String>,
 }
 
@@ -636,11 +637,15 @@ impl ClientWrap {
         cmd.arg(&s);
         cmd.current_dir("/");
 
-        /*
-         * Run the diagnostic script as root:
-         */
-        let passwd = Passwd::by_name("root")?
-            .ok_or_else(|| anyhow!("missing root user"))?;
+        let passwd = if self.config.setuid {
+            /*
+             * Run the diagnostic script as root:
+             */
+            Passwd::by_name("root")?
+                .ok_or_else(|| anyhow!("missing root user"))?
+        } else {
+            Passwd::current_user()?
+        };
         cmd.uid(passwd.uid.0);
         cmd.gid(passwd.gid.0);
 
@@ -652,10 +657,14 @@ impl ClientWrap {
 
         if let Some(dir) = &passwd.dir {
             cmd.env("HOME", dir);
+        } else {
+            bail!("user {} doesn't have a home directory", passwd.uid.0);
         }
         if let Some(name) = &passwd.name {
             cmd.env("USER", name);
             cmd.env("LOGNAME", name);
+        } else {
+            bail!("user {} doesn't have a name", passwd.uid.0);
         }
         cmd.env("TZ", "UTC");
         cmd.env(
@@ -1040,9 +1049,11 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
     l.optopt("N", "", "set nodename of machine", "NODENAME");
     l.optmulti("e", "", "add environment variables", "KEY=VALUE");
     l.optflag("", "no-service", "avoid creating the system service");
+    l.optflag("", "no-setuid", "prevent the agent from changing users");
 
     let a = args!(l);
     let start_service = !a.opts().opt_present("no-service");
+    let setuid = !a.opts().opt_present("no-setuid");
     let log = l.context().log.clone();
 
     /*
@@ -1081,7 +1092,7 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
      */
     make_dirs_for(CONFIG_PATH)?;
     rmfile(CONFIG_PATH)?;
-    let cf = ConfigFile { baseurl, bootstrap, token: genkey(64), env };
+    let cf = ConfigFile { baseurl, bootstrap, token: genkey(64), setuid, env };
     store(CONFIG_PATH, &cf)?;
 
     /*
@@ -1624,12 +1635,19 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                  * account or with a different working directory.
                  */
                 cmd.current_dir(&t.workdir);
-                cmd.uid(t.uid);
-                cmd.gid(t.gid);
-
-                let passwd = Passwd::by_uid(Uid(t.uid))?.ok_or_else(|| {
-                    anyhow!("no user on the system with uid {}", t.uid)
-                })?;
+                let passwd = if cf.setuid {
+                    cmd.uid(t.uid);
+                    cmd.gid(t.gid);
+                    Passwd::by_uid(Uid(t.uid))?.ok_or_else(|| {
+                        anyhow!("no user on the system with uid {}", t.uid)
+                    })?
+                } else {
+                    /*
+                     * XXX should we handle when a different uid/gid is
+                     * requested?
+                     */
+                    Passwd::current_user()?
+                };
 
                 /*
                  * The user task should have a pristine and reproducible
@@ -1645,9 +1663,16 @@ async fn cmd_run(mut l: Level<Agent>) -> Result<()> {
                     if let Some(name) = &passwd.name {
                         cmd.env("USER", name);
                         cmd.env("LOGNAME", name);
+                    } else {
+                        bail!(
+                            "user {} doesn't have a home directory",
+                            passwd.uid.0
+                        );
                     }
                     if let Some(dir) = &passwd.dir {
                         cmd.env("HOME", dir);
+                    } else {
+                        bail!("user {} doesn't have a name", passwd.uid.0);
                     }
                     cmd.env("TZ", "UTC");
                     cmd.env(

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -47,17 +47,10 @@ const AGENT: &str = "/opt/buildomat/lib/agent";
 const INPUT_PATH: &str = "/input";
 const CONTROL_PROGRAM: &str = "bmat";
 const SHADOW: &str = "/etc/shadow";
-#[cfg(target_os = "illumos")]
-mod os_constants {
-    pub const METHOD: &str = "/opt/buildomat/lib/start.sh";
-    pub const MANIFEST: &str = "/var/svc/manifest/site/buildomat-agent.xml";
-    pub const INPUT_DATASET: &str = "rpool/input";
-}
-#[cfg(target_os = "linux")]
-mod os_constants {
-    pub const UNIT: &str = "/etc/systemd/system/buildomat-agent.service";
-}
-use os_constants::*;
+const ILLUMOS_METHOD: &str = "/opt/buildomat/lib/start.sh";
+const ILLUMOS_MANIFEST: &str = "/var/svc/manifest/site/buildomat-agent.xml";
+const ILLUMOS_INPUT_DATASET: &str = "rpool/input";
+const LINUX_UNIT: &str = "/etc/systemd/system/buildomat-agent.service";
 
 use crate::control::protocol::StoreEntry;
 
@@ -1100,20 +1093,19 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
     std::fs::copy(&exe, &cprog)?;
     make_executable(&cprog)?;
 
-    #[cfg(target_os = "illumos")]
-    {
+    if cfg!(target_os = "illumos") {
         /*
          * Copy SMF method script and manifest into place.
          */
         let method = include_str!("../smf/start.sh");
-        make_dirs_for(METHOD)?;
-        rmfile(METHOD)?;
-        write_text(METHOD, method)?;
-        make_executable(METHOD)?;
+        make_dirs_for(ILLUMOS_METHOD)?;
+        rmfile(ILLUMOS_METHOD)?;
+        write_text(ILLUMOS_METHOD, method)?;
+        make_executable(ILLUMOS_METHOD)?;
 
         let manifest = include_str!("../smf/agent.xml");
-        rmfile(MANIFEST)?;
-        write_text(MANIFEST, manifest)?;
+        rmfile(ILLUMOS_MANIFEST)?;
+        write_text(ILLUMOS_MANIFEST, manifest)?;
 
         /*
          * Create the input directory.
@@ -1122,7 +1114,7 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
             .arg("create")
             .arg("-o")
             .arg(format!("mountpoint={INPUT_PATH}"))
-            .arg(INPUT_DATASET)
+            .arg(ILLUMOS_INPUT_DATASET)
             .env_clear()
             .current_dir("/")
             .status();
@@ -1137,7 +1129,7 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
          */
         let status = Command::new("/usr/sbin/svccfg")
             .arg("import")
-            .arg(MANIFEST)
+            .arg(ILLUMOS_MANIFEST)
             .env_clear()
             .current_dir("/")
             .status();
@@ -1146,10 +1138,7 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
             Ok(o) => bail!("svccfg import failure: {:?}", o),
             Err(e) => bail!("could not execute svccfg import: {:?}", e),
         }
-    }
-
-    #[cfg(target_os = "linux")]
-    {
+    } else if cfg!(target_os = "linux") {
         /*
          * Create the input directory.
          */
@@ -1159,9 +1148,9 @@ async fn cmd_install(mut l: Level<Agent>) -> Result<()> {
          * Write a systemd unit file for the agent service.
          */
         let unit = include_str!("../systemd/agent.service");
-        make_dirs_for(UNIT)?;
-        rmfile(UNIT)?;
-        write_text(UNIT, unit)?;
+        make_dirs_for(LINUX_UNIT)?;
+        rmfile(LINUX_UNIT)?;
+        write_text(LINUX_UNIT, unit)?;
 
         /*
          * Ask systemd to load the unit file we just wrote.

--- a/client/openapi.json
+++ b/client/openapi.json
@@ -922,6 +922,42 @@
         }
       }
     },
+    "/0/factory/worker/{worker}/fail": {
+      "post": {
+        "operationId": "factory_worker_fail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "worker",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FactoryWorkerFail"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/0/factory/worker/{worker}/flush": {
       "post": {
         "operationId": "factory_worker_flush",
@@ -2941,6 +2977,17 @@
         },
         "required": [
           "target"
+        ]
+      },
+      "FactoryWorkerFail": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "reason"
         ]
       },
       "FactoryWorkerResult": {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true }
+libc = { workspace = true }
 new_mime_guess = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { workspace = true }
 libc = { workspace = true }
 new_mime_guess = { workspace = true }
 rand = { workspace = true }
+rand_pcg = { workspace = true }
 regex = { workspace = true }
 rusty_ulid = { workspace = true }
 serde = { workspace = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -12,7 +12,8 @@ use std::time::Duration;
 use anyhow::Result;
 use chrono::prelude::*;
 use rand::distr::Alphanumeric;
-use rand::{rng, RngExt as _};
+use rand::{rng, Rng, RngExt, SeedableRng as _};
+use rand_pcg::Pcg64;
 use regex::Regex;
 use rusty_ulid::Ulid;
 use serde::{Deserialize, Serialize};
@@ -61,6 +62,24 @@ pub fn make_log(name: &'static str) -> Logger {
         .fuse();
         Logger::root(dr, o!())
     }
+}
+
+pub fn make_test_log() -> Logger {
+    let dec = slog_term::PlainSyncDecorator::new(slog_term::TestStdoutWriter);
+    let dr = slog_term::FullFormat::new(dec).build().fuse();
+    Logger::root(dr, o!())
+}
+
+pub fn make_test_rng() -> Pcg64 {
+    /*
+     * This is a deterministic rng that is guaranteed not to change behavior
+     * across version bumps.  We can rely on its outputs in assertions.
+     */
+    Pcg64::seed_from_u64(42)
+}
+
+pub fn make_test_ulid<R: Rng>(rng: &mut R) -> Ulid {
+    Ulid::from_timestamp_with_rng(0, rng)
 }
 
 fn bool_env(var: &str) -> bool {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,8 @@
  * Copyright 2025 Oxide Computer Company
  */
 
+pub mod unix;
+
 use std::io::{IsTerminal, Read};
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};

--- a/common/src/unix.rs
+++ b/common/src/unix.rs
@@ -3,6 +3,7 @@
  */
 
 use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString};
 use std::io::{Error as IoError, ErrorKind};
 use std::path::PathBuf;
@@ -60,10 +61,16 @@ pub fn getuid() -> Uid {
     Uid(unsafe { libc::getuid() })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(transparent)]
 pub struct Uid(pub u32);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(transparent)]
 pub struct Gid(pub u32);
 
 fn catch_errno<T, F: Fn() -> T>(f: F) -> Result<T, IoError> {

--- a/common/src/unix.rs
+++ b/common/src/unix.rs
@@ -2,7 +2,7 @@
  * Copyright 2026 Oxide Computer Company
  */
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use std::ffi::{CStr, CString};
 use std::io::{Error as IoError, ErrorKind};
 use std::path::PathBuf;
@@ -15,6 +15,11 @@ pub struct Passwd {
 }
 
 impl Passwd {
+    pub fn current_user() -> Result<Self> {
+        Self::by_uid(getuid())?
+            .ok_or_else(|| anyhow!("missing passwd entry for the current user"))
+    }
+
     pub fn by_name(name: &str) -> Result<Option<Self>> {
         let name = CString::new(name.to_string())?;
         Self::from_libc(catch_errno(|| unsafe {
@@ -49,6 +54,10 @@ impl Passwd {
             },
         }))
     }
+}
+
+pub fn getuid() -> Uid {
+    Uid(unsafe { libc::getuid() })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/common/src/unix.rs
+++ b/common/src/unix.rs
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use anyhow::Result;
+use std::ffi::{CStr, CString};
+use std::io::{Error as IoError, ErrorKind};
+use std::path::PathBuf;
+
+pub struct Passwd {
+    pub uid: Uid,
+    pub gid: Gid,
+    pub name: Option<String>,
+    pub dir: Option<PathBuf>,
+}
+
+impl Passwd {
+    pub fn by_name(name: &str) -> Result<Option<Self>> {
+        let name = CString::new(name.to_string())?;
+        Self::from_libc(catch_errno(|| unsafe {
+            libc::getpwnam(name.as_ptr())
+        })?)
+    }
+
+    pub fn by_uid(uid: Uid) -> Result<Option<Self>> {
+        Self::from_libc(catch_errno(|| unsafe { libc::getpwuid(uid.0) })?)
+    }
+
+    fn from_libc(ptr: *const libc::passwd) -> Result<Option<Self>> {
+        let passwd = match unsafe { ptr.as_ref() } {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+
+        Ok(Some(Passwd {
+            uid: Uid(passwd.pw_uid),
+            gid: Gid(passwd.pw_gid),
+            name: if passwd.pw_name.is_null() {
+                None
+            } else {
+                let cstr = unsafe { CStr::from_ptr(passwd.pw_name) };
+                Some(cstr.to_str()?.into())
+            },
+            dir: if passwd.pw_dir.is_null() {
+                None
+            } else {
+                let cstr = unsafe { CStr::from_ptr(passwd.pw_dir) };
+                Some(cstr.to_str()?.into())
+            },
+        }))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Uid(pub u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Gid(pub u32);
+
+fn catch_errno<T, F: Fn() -> T>(f: F) -> Result<T, IoError> {
+    loop {
+        clear_errno();
+        let result = f();
+        let err = IoError::last_os_error();
+        if err.raw_os_error() == Some(0) {
+            return Ok(result);
+        } else if let ErrorKind::Interrupted = err.kind() {
+            continue;
+        } else {
+            return Err(err);
+        }
+    }
+}
+
+#[cfg(target_os = "illumos")]
+fn clear_errno() {
+    unsafe {
+        let errno = libc::___errno();
+        *errno = 0;
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn clear_errno() {
+    unsafe {
+        let errno = libc::__errno_location();
+        *errno = 0;
+    }
+}

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -258,7 +258,6 @@ macro_rules! sqlite_ulid_new_type {
             PartialOrd,
             Ord,
             Hash,
-            Debug,
             serde::Serialize,
             serde::Deserialize,
             $($derives),*
@@ -308,6 +307,12 @@ macro_rules! sqlite_ulid_new_type {
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{}", self.0.to_string())
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}({})", stringify!($name), self.0.to_string())
             }
         }
 

--- a/factory/user/Cargo.toml
+++ b/factory/user/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "buildomat-factory-user"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+buildomat-common = { path = "../../common" }
+buildomat-database = { path = "../../database" }
+buildomat-client = { path = "../../client" }
+buildomat-types = { path = "../../types" }
+
+anyhow = { workspace = true }
+async-compression = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
+getopts = { workspace = true }
+libc = { workspace = true }
+rand = { workspace = true }
+reqwest = { workspace = true } 
+rusty_ulid = { workspace = true }
+schemars = { workspace = true }
+sea-query = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+slog = { workspace = true }
+slog-term = { workspace = true }
+smf = { workspace = true }
+strum = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+toml = { workspace = true }
+usdt = { workspace = true }
+
+[dev-dependencies]
+expect-test = { workspace = true }

--- a/factory/user/README.md
+++ b/factory/user/README.md
@@ -1,0 +1,68 @@
+# User Factory
+
+The user factory creates unprivileged users on a shared illumos machine to run
+jobs.  The factory ensures each job runs in an ephemeral system user with no
+privileges and no ability to write files outside of allowlisted directories, and
+cleans up any leftover files at the end of the job.
+
+It currently only supports running on illumos, and requires that the factory
+runs with the `Primary Administrator` profile.
+
+## Slots 
+
+The factory configuration has to define one or more named "slots".  Each slot
+has a buildomat target it supports, plus optional configuration to define its
+execution environment.  When the a job comes in from the buildomat core server,
+the factory will only accept it if there is a free slot for that job's target.
+This means the number of slots is also the concurrency limit on that system.
+
+The minimal slot configuration requires only a slot name and the ID of the
+buildomat target the slot supports:
+
+```toml
+[slots.NAME]
+target = "TARGET_ID"
+```
+
+Additional configuration options are available:
+
+* **`add_to_groups = ["GROUP", "GROUP"]`**: add the ephemeral system user to
+  these groups in addition to the primary (ephemeral) group.  This can be useful
+  to allow jobs running in the slot to access system capabilities guarded by
+  group membership.
+
+* **`conflicts_with_slots = ["SLOT", "SLOT"]`**: prevent a job from running in
+  this slot if any job is running in one of the configured conflicting jobs.
+  The reverse also applies: a job running in a conflicting slot will prevent a
+  job from running in the current slot.
+
+* **`env.KEY = "VALUE"`**: set arbitrary environment variables in jobs executed
+  inside of this slot.
+
+An example of a full slot configuration:
+
+```toml
+[slots.hubris-1]
+target = "..."
+add_to_groups = ["usb"]
+conflicts_with_slots = ["hubris-2"]
+env.HUMILITY_ENVIRONMENT = "/opt/ci/humility/1.json"
+```
+
+## Isolation
+
+Each job runs as an ephemeral user, with randomly generated UID and GID,
+guaranteed not to collide with any UID and GID currently in use on the system.
+The name of the user is the worker ID prefixed by `bmat-`.
+
+The whole filesystem is enforced to be read-only, except for a few allowlisted
+directories. All writeable directories are empty at the time the job starts, and
+are purged at the end of the job. The following directiories are writeable:
+
+* `/home/$USER`
+* `/input`
+* `/opt/buildomat` (used by the buildomat agent)
+* `/tmp`
+* `/var/run` (used by the buildomat agent)
+* `/var/tmp`
+* `/work`

--- a/factory/user/schema.sql
+++ b/factory/user/schema.sql
@@ -1,0 +1,11 @@
+-- v 1
+CREATE TABLE worker (
+    id              TEXT    NOT NULL    PRIMARY KEY,
+    slot            TEXT    NOT NULL,
+    state           TEXT    NOT NULL,
+    leased_job      TEXT    NOT NULL,
+    bootstrap       TEXT    NOT NULL
+);
+
+-- v 2
+CREATE INDEX worker_state ON worker (state);

--- a/factory/user/smf/worker.xml
+++ b/factory/user/smf/worker.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle name='buildomat-worker' type='manifest'>
+    <service name='site/buildomat/factory-user-worker' type='service' version='0'>
+        <exec_method name='start' type='method' timeout_seconds='60' exec='/opt/buildomat/lib/factory-user __bootstrap_agent' />
+        <exec_method name='stop' type='method' timeout_seconds='60' exec=':kill' />
+    </service>
+</service_bundle>

--- a/factory/user/src/bootstrap_agent.rs
+++ b/factory/user/src/bootstrap_agent.rs
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use async_compression::tokio::write::GzipDecoder;
+use buildomat_client::prelude::StreamExt as _;
+use smf::{scf_type_t, Property, PropertyGroup, Scf, Snapshot};
+use std::collections::{BTreeMap, HashMap};
+use std::os::unix::fs::{chroot, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+use tempfile::{NamedTempFile, TempPath};
+use tokio::fs::File;
+use tokio::io::BufWriter;
+
+pub(crate) async fn run() -> Result<()> {
+    let ctx = BootstrapContext::from_smf()?;
+
+    /*
+     * We want to run the agent inside of a chroot where most of the filesystem
+     * is read-only and we have isolated writeable directories.  The factory
+     * prepares the chroot for us, we just need to get into it.
+     */
+    chroot(&ctx.chroot)
+        .with_context(|| format!("failed to chroot in {:?}", ctx.chroot))?;
+
+    let agent = download_agent(&ctx).await?;
+    mark_executable(&agent).await?;
+
+    let mut cmd = Command::new(&agent);
+    cmd.arg("install");
+    for (k, v) in &ctx.env {
+        cmd.arg("-e").arg(format!("{k}={v}"));
+    }
+    cmd.arg("--no-service");
+    cmd.arg("--no-setuid");
+    cmd.arg("--use-var-run");
+    cmd.arg(&ctx.baseurl).arg(&ctx.bootstrap_token);
+
+    cmd.spawn().context("failed to start the agent")?;
+
+    Ok(())
+}
+
+async fn download_agent(ctx: &BootstrapContext) -> Result<TempPath> {
+    let baseurl = &ctx.baseurl;
+    let query = agent_query_string()?;
+    loop {
+        println!("attempting to download the gz agent...");
+        match download_gz(format!("{baseurl}/file/agent.gz?{query}")).await {
+            Ok(dest) => return Ok(dest),
+            Err(e) => {
+                eprintln!("failed to download gz agent: {e}");
+            }
+        }
+
+        println!("attempting to download the plaintext agent...");
+        match download_plain(format!("{baseurl}/file/agent?{query}")).await {
+            Ok(dest) => return Ok(dest),
+            Err(e) => {
+                eprintln!("failed to download plaintext agent: {e}");
+            }
+        }
+
+        println!("downloads failed, retrying in a second");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn download_gz(url: String) -> Result<TempPath> {
+    let (dest, dest_path) = NamedTempFile::new()?.into_parts();
+
+    let mut resp = reqwest::get(&url).await?.error_for_status()?.bytes_stream();
+    let mut dest = GzipDecoder::new(BufWriter::new(File::from_std(dest)));
+
+    while let Some(chunk) = resp.next().await {
+        tokio::io::copy(&mut chunk?.as_ref(), &mut dest).await.with_context(
+            || format!("failed to download {url:?} to {dest_path:?}"),
+        )?;
+    }
+
+    Ok(dest_path)
+}
+
+async fn download_plain(url: String) -> Result<TempPath> {
+    let (dest, dest_path) = NamedTempFile::new()?.into_parts();
+
+    let mut resp = reqwest::get(&url).await?.error_for_status()?.bytes_stream();
+    let mut dest = BufWriter::new(File::from_std(dest));
+
+    while let Some(chunk) = resp.next().await {
+        tokio::io::copy(&mut chunk?.as_ref(), &mut dest).await.with_context(
+            || format!("failed to download {url:?} to {dest_path:?}"),
+        )?;
+    }
+
+    Ok(dest_path)
+}
+
+async fn mark_executable(path: &Path) -> Result<()> {
+    let mut perms = tokio::fs::metadata(path).await?.permissions();
+    perms.set_mode(0o755);
+    tokio::fs::set_permissions(path, perms).await?;
+    Ok(())
+}
+
+/*
+ * Give the server some hints as to what OS we're running so that it can give us
+ * the most appropriate agent binary.
+ */
+fn agent_query_string() -> Result<String> {
+    let os_release = std::fs::read_to_string("/etc/os-release")
+        .context("failed to read /etc/os-release")?;
+    let mut os_release = os_release
+        .split('\n')
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .flat_map(|line| line.split_once('='))
+        .collect::<HashMap<_, _>>();
+
+    let mut query = Vec::new();
+    query.push(format!("kernel={}", command_output("uname", &["-r"])?));
+    query.push(format!("proc={}", command_output("uname", &["-p"])?));
+    query.push(format!("mach={}", command_output("uname", &["-m"])?));
+    query.push(format!("plat={}", command_output("uname", &["-i"])?));
+    query.push(format!("id={}", os_release.remove("ID").unwrap_or_default()));
+    query.push(format!(
+        "id_like={}",
+        os_release.remove("ID_LIKE").unwrap_or_default()
+    ));
+    query.push(format!(
+        "version_id={}",
+        os_release.remove("VERSION_ID").unwrap_or_default()
+    ));
+    Ok(query.join("&"))
+}
+
+#[derive(Debug)]
+pub(crate) struct BootstrapContext {
+    pub(crate) baseurl: String,
+    pub(crate) bootstrap_token: String,
+    pub(crate) chroot: PathBuf,
+    pub(crate) env: BTreeMap<String, String>,
+}
+
+impl BootstrapContext {
+    fn from_smf() -> Result<Self> {
+        let scf = Scf::new().context("failed to connect to SMF")?;
+        let inst = scf
+            .get_self_instance()
+            .context("failed to get the current SMF instance")?;
+        let snapshot = inst
+            .get_running_snapshot()
+            .context("failed to get the running SMF snapshot")?;
+
+        let pg = get_pg(&snapshot, "buildomat")?;
+        let pg_env = get_pg(&snapshot, "buildomat-env")?;
+
+        let mut env = BTreeMap::new();
+        for prop in pg_env.properties().context("failed to list properties")? {
+            let prop = prop.context("failed to list properties")?;
+            env.insert(prop.name()?, prop_value(&pg_env, &prop)?);
+        }
+
+        Ok(BootstrapContext {
+            baseurl: get_prop(&pg, "baseurl")?,
+            bootstrap_token: get_prop(&pg, "bootstrap_token")?,
+            chroot: get_prop(&pg, "chroot")?.into(),
+            env,
+        })
+    }
+}
+
+fn get_pg<'a>(snap: &'a Snapshot<'a>, name: &str) -> Result<PropertyGroup<'a>> {
+    snap.get_pg(name)
+        .with_context(|| format!("failed to get property group {name:?}"))?
+        .ok_or_else(|| anyhow!("missing property group {name:?}"))
+}
+
+fn get_prop(pg: &PropertyGroup<'_>, name: &str) -> Result<String> {
+    let id = format!("{}/{name}", pg.name()?);
+    let prop = pg
+        .get_property(name)
+        .with_context(|| format!("failed to get property {id:?}"))?
+        .ok_or_else(|| anyhow!("missing property {id:?}"))?;
+
+    prop_value(pg, &prop)
+}
+
+fn prop_value(pg: &PropertyGroup<'_>, prop: &Property<'_>) -> Result<String> {
+    let id = format!("{}/{}", pg.name()?, prop.name()?);
+
+    if !matches!(prop.type_()?, scf_type_t::SCF_TYPE_ASTRING) {
+        bail!("property {id:?} is not of type astring");
+    }
+
+    let value = prop
+        .value()
+        .with_context(|| format!("failed to get value of property {id:?}"))?
+        .ok_or_else(|| anyhow!("missing value of property {id:?}"))?;
+
+    value
+        .as_string()
+        .with_context(|| format!("failed to coerce property {id:?} as string"))
+}
+
+fn command_output(cmd: &str, args: &[&str]) -> Result<String> {
+    let output = Command::new(cmd)
+        .args(args)
+        .stdout(Stdio::piped())
+        .spawn()?
+        .wait_with_output()?;
+    if !output.status.success() {
+        bail!("{cmd} failed with {}", output.status);
+    }
+    Ok(String::from_utf8(output.stdout)
+        .context("non-UTF-8 output")?
+        .trim_end_matches(['\n', '\r'])
+        .into())
+}

--- a/factory/user/src/config.rs
+++ b/factory/user/src/config.rs
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use crate::db::types::TargetId;
+use anyhow::{bail, Result};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashSet};
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ConfigFile {
+    pub(crate) general: ConfigFileGeneral,
+    pub(crate) factory: ConfigFileFactory,
+    #[serde(default)]
+    pub(crate) illumos: ConfigFileIllumos,
+    pub(crate) slots: BTreeMap<String, ConfigFileSlot>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ConfigFileGeneral {
+    pub(crate) baseurl: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ConfigFileFactory {
+    pub(crate) token: String,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ConfigFileIllumos {
+    pub(crate) parent_zfs_dataset: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ConfigFileSlot {
+    pub(crate) target: TargetId,
+    #[serde(default)]
+    pub(crate) conflicts_with_slots: Vec<String>,
+    #[serde(default)]
+    pub(crate) add_to_groups: Vec<String>,
+    #[serde(default)]
+    pub(crate) env: BTreeMap<String, String>,
+}
+
+pub(crate) fn validate_config(config: &ConfigFile) -> Result<()> {
+    /*
+     * Validate that conflicts_with_slots is not malformed.
+     */
+    let slot_names = config.slots.keys().collect::<HashSet<_>>();
+    for (slot_name, slot) in &config.slots {
+        for conflict in &slot.conflicts_with_slots {
+            if conflict == slot_name {
+                bail!("slot {slot_name:?} cannot conflict with itself");
+            }
+            if !slot_names.contains(conflict) {
+                bail!(
+                    "slot {slot_name:?} cannot conflict with unknown \
+                     slot {conflict:?}"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) struct ConfigBuilder {
+    inner: ConfigFile,
+}
+
+#[cfg(test)]
+impl ConfigBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: ConfigFile {
+                general: ConfigFileGeneral {
+                    baseurl: "http://buildomat.invalid:9979".into(),
+                },
+                factory: ConfigFileFactory { token: "".into() },
+                illumos: ConfigFileIllumos { parent_zfs_dataset: None },
+                slots: BTreeMap::new(),
+            },
+        }
+    }
+
+    pub(crate) fn slot(
+        mut self,
+        name: &str,
+        target: TargetId,
+        mutate: impl FnOnce(&mut ConfigFileSlot),
+    ) -> Self {
+        let mut slot = ConfigFileSlot {
+            target,
+            conflicts_with_slots: Vec::new(),
+            add_to_groups: Vec::new(),
+            env: BTreeMap::new(),
+        };
+        mutate(&mut slot);
+        self.inner.slots.insert(name.into(), slot);
+        self
+    }
+
+    pub(crate) fn build(self) -> ConfigFile {
+        self.inner
+    }
+}

--- a/factory/user/src/coordinator.rs
+++ b/factory/user/src/coordinator.rs
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use crate::db::types::*;
+use crate::Central;
+use anyhow::Result;
+use slog::{error, info, o, Logger};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+
+pub(crate) async fn coordinator_loop(c: Arc<Central>) {
+    let log = c.log.new(o!("component" => "coordinator"));
+
+    let mut tasks = HashMap::new();
+    loop {
+        if let Err(e) = coordinator_iteration(&log, &c, &mut tasks).await {
+            error!(log, "coordinator error: {e:?}");
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn coordinator_iteration(
+    log: &Logger,
+    c: &Arc<Central>,
+    tasks: &mut HashMap<WorkerId, Task>,
+) -> Result<()> {
+    let mut to_spawn = Vec::new();
+    let mut to_stop = Vec::new();
+
+    /*
+     * Tasks that manage a worker tracked in the database.
+     */
+    let workers = c.db.workers()?;
+    for worker in &workers {
+        if let WorkerState::Destroyed = worker.state {
+            to_stop.push(worker.id);
+        }
+        if let Some(task) = tasks.get(&worker.id) {
+            if task.join_handle.is_finished() {
+                /*
+                 * If the task exited but the worker is not marked as destroyed,
+                 * start the task again.  This can only happen with panics.
+                 */
+                to_spawn.push(worker.id);
+            }
+        } else {
+            to_spawn.push(worker.id);
+        }
+    }
+
+    /*
+     * Tasks that manage a worker *not* tracked in the database.
+     */
+    let worker_ids = workers.iter().map(|w| w.id).collect::<HashSet<_>>();
+    for id in tasks.keys() {
+        if !worker_ids.contains(id) {
+            to_stop.push(*id);
+        }
+    }
+
+    for worker_id in to_stop {
+        let Some(task) = tasks.get(&worker_id) else { continue };
+
+        if task.join_handle.is_finished() {
+            tasks.remove(&worker_id);
+        } else if !task.stop.swap(true, Ordering::Relaxed) {
+            info!(log, "stopping task for worker {worker_id}");
+        }
+    }
+
+    for worker_id in to_spawn {
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let join_handle = tokio::spawn(worker_loop(
+            Arc::clone(c),
+            worker_id,
+            Arc::clone(&stop),
+        ));
+
+        info!(log, "spawned task for worker {worker_id}");
+        tasks.insert(worker_id, Task { stop, join_handle });
+    }
+
+    Ok(())
+}
+
+async fn worker_loop(c: Arc<Central>, id: WorkerId, stop: Arc<AtomicBool>) {
+    let log = c.log.new(o!(
+        "component" => "worker",
+        "worker" => id.to_string(),
+    ));
+
+    while !stop.load(Ordering::Relaxed) {
+        match crate::illumos::worker_iteration(&log, &c, id).await {
+            Ok(DoNext::Immediate) => {}
+            Ok(DoNext::Sleep) => {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(err) => {
+                error!(log, "worker {id} iteration failed: {err}");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+pub(crate) enum DoNext {
+    Sleep,
+    Immediate,
+}
+
+struct Task {
+    join_handle: JoinHandle<()>,
+    stop: Arc<AtomicBool>,
+}

--- a/factory/user/src/db/mod.rs
+++ b/factory/user/src/db/mod.rs
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use crate::db::types::WorkerId;
+use anyhow::Result;
+use buildomat_database::{conflict, DBResult, FromRow, Sqlite};
+use sea_query::{Expr, Order, Query};
+use slog::Logger;
+use std::path::Path;
+
+mod tables;
+
+pub mod types {
+    use buildomat_database::{
+        rusqlite, sqlite_integer_new_type, sqlite_ulid_new_type,
+    };
+
+    sqlite_ulid_new_type!(JobId);
+    sqlite_ulid_new_type!(TargetId);
+    sqlite_ulid_new_type!(WorkerId);
+    sqlite_integer_new_type!(InstanceSeq, u64, BigUnsigned);
+
+    pub use super::tables::WorkerState;
+}
+
+pub use tables::*;
+
+pub struct Database {
+    sql: Sqlite,
+}
+
+impl Database {
+    pub fn new<P: AsRef<Path>>(
+        log: Logger,
+        path: P,
+        cache_kb: Option<u32>,
+    ) -> Result<Database> {
+        let sql = Sqlite::setup(
+            log,
+            path,
+            include_str!("../../schema.sql"),
+            cache_kb,
+        )?;
+
+        Ok(Database { sql })
+    }
+
+    pub fn workers(&self) -> DBResult<Vec<Worker>> {
+        self.sql.tx(|tx| {
+            tx.get_rows(
+                Query::select()
+                    .from(WorkerDef::Table)
+                    .columns(Worker::columns())
+                    .order_by(WorkerDef::Id, Order::Asc)
+                    .to_owned(),
+            )
+        })
+    }
+
+    pub fn worker_get(&self, id: WorkerId) -> DBResult<Option<Worker>> {
+        self.sql.tx(|tx| tx.get_row_opt(Worker::find(id)))
+    }
+
+    pub fn worker_create(&self, create: Worker) -> DBResult<WorkerId> {
+        self.sql.tx_immediate(|h| {
+            let count = h.exec_insert(create.insert())?;
+            assert_eq!(count, 1);
+            Ok(create.id)
+        })
+    }
+
+    pub fn worker_delete(&self, id: WorkerId) -> DBResult<()> {
+        self.sql.tx_immediate(|h| {
+            let count = h.exec_delete(
+                Query::delete()
+                    .from_table(WorkerDef::Table)
+                    .and_where(Expr::col(WorkerDef::Id).eq(id))
+                    .to_owned(),
+            )?;
+            assert_eq!(count, 1);
+            Ok(())
+        })
+    }
+
+    pub fn worker_new_state(
+        &self,
+        id: WorkerId,
+        state: WorkerState,
+    ) -> DBResult<()> {
+        self.sql.tx_immediate(|tx| {
+            /*
+             * Get the existing state of this worker:
+             */
+            let worker: Worker = tx.get_row(Worker::find(id))?;
+
+            if worker.state == state {
+                return Ok(());
+            }
+
+            let valid_source_states: &[WorkerState] = match state {
+                WorkerState::Unconfigured => &[],
+                WorkerState::Configured => &[WorkerState::Unconfigured],
+                WorkerState::Broken => {
+                    &[WorkerState::Unconfigured, WorkerState::Configured]
+                }
+                WorkerState::Destroying => &[
+                    WorkerState::Broken,
+                    WorkerState::Unconfigured,
+                    WorkerState::Configured,
+                ],
+                WorkerState::Destroyed => &[WorkerState::Destroying],
+            };
+
+            if !valid_source_states.contains(&worker.state) {
+                conflict!(
+                    "worker {id} cannot move from state {} to {state}",
+                    worker.state,
+                );
+            }
+
+            let count = tx.exec_update(
+                Query::update()
+                    .table(WorkerDef::Table)
+                    .and_where(Expr::col(WorkerDef::Id).eq(id))
+                    .value(WorkerDef::State, state)
+                    .to_owned(),
+            )?;
+            assert_eq!(count, 1);
+            Ok(())
+        })
+    }
+}

--- a/factory/user/src/db/tables/mod.rs
+++ b/factory/user/src/db/tables/mod.rs
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+mod sublude {
+    pub use std::str::FromStr;
+
+    pub use crate::db::types::*;
+    pub use buildomat_database::{rusqlite, sqlite_sql_enum, FromRow};
+    pub use rusqlite::Row;
+    pub use sea_query::{
+        enum_def, ColumnRef, Expr, Iden, InsertStatement, Query, SeaRc,
+        SelectStatement,
+    };
+}
+
+mod worker;
+
+pub use worker::*;

--- a/factory/user/src/db/tables/worker.rs
+++ b/factory/user/src/db/tables/worker.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use super::sublude::*;
+
+sqlite_sql_enum!(WorkerState => {
+    Unconfigured,
+    Configured,
+    Broken,
+    Destroying,
+    Destroyed,
+});
+
+#[derive(Clone, Debug)]
+#[enum_def(prefix = "", suffix = "Def")]
+pub(crate) struct Worker {
+    pub(crate) id: WorkerId,
+    pub(crate) slot: String,
+    pub(crate) state: WorkerState,
+    pub(crate) leased_job: JobId,
+    pub(crate) bootstrap: String,
+}
+
+impl FromRow for Worker {
+    fn columns() -> Vec<ColumnRef> {
+        [
+            WorkerDef::Id,
+            WorkerDef::Slot,
+            WorkerDef::State,
+            WorkerDef::LeasedJob,
+            WorkerDef::Bootstrap,
+        ]
+        .into_iter()
+        .map(|col| {
+            ColumnRef::TableColumn(
+                SeaRc::new(WorkerDef::Table),
+                SeaRc::new(col),
+            )
+        })
+        .collect()
+    }
+
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        Ok(Worker {
+            id: row.get(0)?,
+            slot: row.get(1)?,
+            state: row.get(2)?,
+            leased_job: row.get(3)?,
+            bootstrap: row.get(4)?,
+        })
+    }
+}
+
+impl Worker {
+    pub(crate) fn find(id: WorkerId) -> SelectStatement {
+        Query::select()
+            .from(WorkerDef::Table)
+            .columns(Worker::columns())
+            .and_where(Expr::col(WorkerDef::Id).eq(id))
+            .to_owned()
+    }
+
+    pub(crate) fn insert(&self) -> InsertStatement {
+        Query::insert()
+            .into_table(WorkerDef::Table)
+            .columns(Self::bare_columns())
+            .values_panic([
+                self.id.into(),
+                self.slot.clone().into(),
+                self.state.into(),
+                self.leased_job.into(),
+                self.bootstrap.clone().into(),
+            ])
+            .to_owned()
+    }
+}

--- a/factory/user/src/factory.rs
+++ b/factory/user/src/factory.rs
@@ -1,0 +1,446 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use crate::config::ConfigFile;
+use crate::db::{types::*, Worker};
+use crate::Central;
+use anyhow::Result;
+use slog::{debug, error, info, o, warn, Logger};
+use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+async fn reconcile_with_server(log: &Logger, c: &Arc<Central>) -> Result<()> {
+    /*
+     * For each worker we are tracking in the local database, check to see if
+     * its server record still exists.  If it does not, destroy the worker.
+     */
+    for worker in c.db.workers()? {
+        match worker.state {
+            WorkerState::Unconfigured
+            | WorkerState::Configured
+            | WorkerState::Broken => {}
+            WorkerState::Destroying | WorkerState::Destroyed => {
+                /*
+                 * We don't need to keep looking at workers that are currently
+                 * being destroyed.
+                 */
+                continue;
+            }
+        }
+
+        let id = worker.id;
+        let leased_job = worker.leased_job;
+        let server_worker = c
+            .client
+            .factory_worker_get()
+            .worker(id.to_string())
+            .send()
+            .await?
+            .into_inner()
+            .worker;
+
+        if let Some(server_worker) = server_worker {
+            if server_worker.recycle {
+                /*
+                 * If the worker has been deleted through the administrative API
+                 * then we need to tear it down straight away.
+                 */
+                info!(log, "worker {id} recycled, destroying it");
+                c.db.worker_new_state(id, WorkerState::Destroying)?;
+            } else if !matches!(worker.state, WorkerState::Broken)
+                && !server_worker.online
+            {
+                /*
+                 * If the worker has not yet bootstrapped try to renew the
+                 * lease with the server.  This should prevent duplicate
+                 * instance creation when creation or bootstrap is taking
+                 * longer than expected.
+                 */
+                debug!(
+                    log,
+                    "worker {id} has not bootstrapped yet, \
+                     renewing lease for job {leased_job}"
+                );
+                c.client
+                    .factory_lease_renew()
+                    .job(leased_job.to_string())
+                    .send()
+                    .await?;
+            }
+        } else {
+            warn!(log, "worker {id} missing from the server, destroying it");
+            c.db.worker_new_state(id, WorkerState::Destroying)?;
+        };
+    }
+
+    /*
+     * At this point we have examined all of the workers which exist in the
+     * local database.  If there are any worker records on the server left that
+     * do not have an associated record in the factory, they must be scrubbed
+     * from the server as detritus from prior failed runs.
+     */
+    for worker in c.client.factory_workers().send().await?.into_inner() {
+        let id = WorkerId::from_str(&worker.id)?;
+
+        /*
+         * There is a record of a particular instance ID for this worker.
+         * Check to see if that instance exists.
+         */
+        if let Some(local) = c.db.worker_get(id)? {
+            if matches!(local.state, WorkerState::Destroyed) {
+                /*
+                 * The worker exists, but is terminated.  Delete the
+                 * worker on the server too.
+                 */
+                info!(log, "deleting terminated worker {id} from the server");
+                c.client
+                    .factory_worker_destroy()
+                    .worker(&worker.id)
+                    .send()
+                    .await?;
+                c.db.worker_delete(id)?;
+            } else {
+                if worker.private.is_none() {
+                    /*
+                     * Starting the worker might've failed before we could
+                     * associate the slot with it.  Rectify that now.
+                     */
+                    warn!(
+                        log,
+                        "worker {id} doesn't have a slot associated on the \
+                         server, associating it"
+                    );
+                    c.client
+                        .factory_worker_associate()
+                        .worker(&worker.id)
+                        .body_map(|b| b.private(&local.slot))
+                        .send()
+                        .await?;
+                }
+            }
+        } else {
+            /*
+             * The worker does not exist in the local database.
+             */
+            warn!(log, "clearing unknown worker {id} from the server");
+            c.client.factory_worker_destroy().worker(&worker.id).send().await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn start_worker(log: &Logger, c: &Arc<Central>) -> Result<bool> {
+    let avail = available_slots(log, &c.config, &c.db.workers()?);
+
+    /*
+     * Check to see if the server requires any new workers.
+     */
+    let lease = c
+        .client
+        .factory_lease()
+        .body_map(|b| {
+            b.supported_targets(
+                avail.keys().map(|t| t.to_string()).collect::<Vec<_>>(),
+            )
+        })
+        .send()
+        .await?
+        .into_inner();
+    let Some(lease) = lease.lease else {
+        return Ok(false);
+    };
+
+    /*
+     * Locate a slot for the target the server asked for.
+     */
+    let Some(slot) = avail.get(&lease.target.parse()?).and_then(|s| s.first())
+    else {
+        warn!(
+            log,
+            "server wants target {:?}, but no slots for it are available",
+            lease.target
+        );
+        return Ok(false);
+    };
+
+    /*
+     * Create the worker on the server and save it in the database.  There could
+     * be a failure between the two parts, but reconciliation will handle it (by
+     * deleting the worker from the server).
+     */
+    let worker = c
+        .client
+        .factory_worker_create()
+        .body_map(|b| b.target(&lease.target).wait_for_flush(false))
+        .send()
+        .await?;
+    c.db.worker_create(Worker {
+        id: WorkerId::from_str(&worker.id)?,
+        slot: slot.clone(),
+        state: WorkerState::Unconfigured,
+        leased_job: JobId::from_str(&lease.job)?,
+        bootstrap: worker.bootstrap.to_string(),
+    })?;
+    info!(log, "created worker {}", worker.id);
+
+    /*
+     * Record the slot we used in the server.  If it fails, reconciliation will
+     * take care of updating the value on the server.
+     */
+    c.client
+        .factory_worker_associate()
+        .worker(&worker.id)
+        .body_map(|b| b.private(slot))
+        .send()
+        .await?;
+
+    Ok(true)
+}
+
+fn available_slots(
+    log: &Logger,
+    config: &ConfigFile,
+    workers: &[Worker],
+) -> BTreeMap<TargetId, Vec<String>> {
+    /*
+     * When slot A is configured to conflict with B, that also implies slot B
+     * conflicts with slot A, even if that is not explicitly configured.
+     */
+    let mut reverse_conflicts: BTreeMap<_, Vec<_>> = BTreeMap::new();
+    for (name, slot) in &config.slots {
+        for conflict in &slot.conflicts_with_slots {
+            reverse_conflicts.entry(conflict).or_default().push(name);
+        }
+    }
+
+    let mut used_slots = workers
+        .iter()
+        .filter(|w| !matches!(w.state, WorkerState::Destroyed))
+        .map(|w| &w.slot)
+        .collect::<BTreeSet<_>>();
+    for used in used_slots.clone() {
+        /*
+         * The slot might not be in the configuration if the worker is created
+         * and later its slot is removed from the config.
+         */
+        let Some(slot) = config.slots.get(used) else { continue };
+
+        /*
+         * Mark as used any slot conflicting with an used slot.
+         */
+        used_slots.extend(slot.conflicts_with_slots.iter());
+        if let Some(reverse) = reverse_conflicts.get(used) {
+            used_slots.extend(reverse.iter());
+        }
+    }
+    debug!(log, "slots currently in use: {used_slots:?}");
+
+    let mut result: BTreeMap<_, Vec<_>> = BTreeMap::new();
+    for (name, slot) in &config.slots {
+        if used_slots.contains(name) {
+            continue;
+        }
+        result.entry(slot.target).or_default().push(name.clone());
+    }
+    result
+}
+
+async fn factory_iteration(log: &Logger, c: &Arc<Central>) -> Result<()> {
+    reconcile_with_server(log, c).await?;
+    while start_worker(log, c).await? {}
+    Ok(())
+}
+
+pub(crate) async fn factory_loop(c: Arc<Central>) {
+    let log = c.log.new(o!("component" => "factory"));
+
+    loop {
+        if let Err(e) = factory_iteration(&log, &c).await {
+            error!(log, "factory task error: {:?}", e);
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ConfigBuilder;
+    use buildomat_common::{make_test_log, make_test_rng, make_test_ulid};
+    use expect_test::expect;
+    use rand::Rng;
+
+    #[test]
+    fn test_available_slots_with_no_workers() {
+        let (log, _, cfg) = prep_available_slots_test();
+
+        /*
+         * No workers currently running, all slots should be available.
+         */
+        expect![[r#"
+            {
+                TargetId(0000000000304KTDGRJWP5BP8H): [
+                    "a",
+                ],
+                TargetId(0000000000D8PRE83ZY7H9CR7C): [
+                    "b",
+                    "c",
+                ],
+                TargetId(0000000000EMY607JJG65KGMWT): [
+                    "d",
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&available_slots(&log, &cfg, &[]));
+    }
+
+    #[test]
+    fn test_available_slots_with_only_slot_for_target() {
+        let (log, mut rng, cfg) = prep_available_slots_test();
+
+        /*
+         * A worker is running in slot A, the first target should not be here.
+         */
+        expect![[r#"
+            {
+                TargetId(0000000000D8PRE83ZY7H9CR7C): [
+                    "b",
+                    "c",
+                ],
+                TargetId(0000000000EMY607JJG65KGMWT): [
+                    "d",
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&available_slots(&log, &cfg, &[w(&mut rng, "a")]));
+    }
+
+    #[test]
+    fn test_available_slots_with_multiple_slots_for_target() {
+        let (log, mut rng, cfg) = prep_available_slots_test();
+
+        /*
+         * A worker is running in slot B, all targets should still be there.
+         */
+        expect![[r#"
+            {
+                TargetId(0000000000304KTDGRJWP5BP8H): [
+                    "a",
+                ],
+                TargetId(0000000000D8PRE83ZY7H9CR7C): [
+                    "c",
+                ],
+                TargetId(0000000000EMY607JJG65KGMWT): [
+                    "d",
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&available_slots(&log, &cfg, &[w(&mut rng, "b")]));
+    }
+
+    #[test]
+    fn test_available_slots_with_declared_conflict() {
+        let (log, mut rng, cfg) = prep_available_slots_test();
+
+        /*
+         * A worker is running in slot D, its target should not be there.  Also,
+         * since slot D conflicts with slot C, slot C should also be missing.
+         */
+        let used_d = available_slots(&log, &cfg, &[w(&mut rng, "d")]);
+        expect![[r#"
+            {
+                TargetId(0000000000304KTDGRJWP5BP8H): [
+                    "a",
+                ],
+                TargetId(0000000000D8PRE83ZY7H9CR7C): [
+                    "b",
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&used_d);
+
+        /*
+         * Conflicts are bidirectional.
+         */
+        let used_c = available_slots(&log, &cfg, &[w(&mut rng, "c")]);
+        assert_eq!(used_c, used_d);
+    }
+
+    #[test]
+    fn test_available_slots_with_all_slots_busy() {
+        let (log, mut rng, cfg) = prep_available_slots_test();
+
+        /*
+         * No targets should be available.
+         */
+        expect![[r#"
+            {}
+        "#]]
+        .assert_debug_eq(&available_slots(
+            &log,
+            &cfg,
+            &[
+                w(&mut rng, "a"),
+                w(&mut rng, "b"),
+                w(&mut rng, "c"),
+                w(&mut rng, "d"),
+            ],
+        ));
+    }
+
+    #[test]
+    fn test_available_slots_with_unknown_busy_slot() {
+        let (log, mut rng, cfg) = prep_available_slots_test();
+
+        /*
+         * The unknown slot should be ignored.
+         */
+        expect![[r#"
+            {
+                TargetId(0000000000304KTDGRJWP5BP8H): [
+                    "a",
+                ],
+                TargetId(0000000000D8PRE83ZY7H9CR7C): [
+                    "b",
+                    "c",
+                ],
+                TargetId(0000000000EMY607JJG65KGMWT): [
+                    "d",
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&available_slots(&log, &cfg, &[w(&mut rng, "lol")]));
+    }
+
+    fn prep_available_slots_test() -> (Logger, impl Rng, ConfigFile) {
+        let log = make_test_log();
+        let mut rng = make_test_rng();
+
+        let target1 = TargetId(make_test_ulid(&mut rng));
+        let target2 = TargetId(make_test_ulid(&mut rng));
+        let target3 = TargetId(make_test_ulid(&mut rng));
+
+        let cfg = ConfigBuilder::new()
+            .slot("a", target1, |_| {})
+            .slot("b", target2, |_| {})
+            .slot("c", target2, |_| {})
+            .slot("d", target3, |s| s.conflicts_with_slots = vec!["c".into()])
+            .build();
+
+        (log, rng, cfg)
+    }
+
+    fn w<R: Rng>(rng: &mut R, slot: &str) -> Worker {
+        Worker {
+            id: WorkerId(make_test_ulid(rng)),
+            slot: slot.to_string(),
+            state: WorkerState::Configured,
+            leased_job: JobId(make_test_ulid(rng)),
+            bootstrap: String::new(),
+        }
+    }
+}

--- a/factory/user/src/illumos/chroot.rs
+++ b/factory/user/src/illumos/chroot.rs
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use crate::db::types::WorkerId;
+use crate::Central;
+use anyhow::{anyhow, bail, Context as _, Result};
+use buildomat_common::unix::{Passwd, Uid};
+use buildomat_common::OutputExt as _;
+use std::fs::Permissions;
+use std::os::unix::fs::{chown, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const ZFS: &str = "/usr/sbin/zfs";
+const MOUNT: &str = "/usr/sbin/mount";
+const UMOUNT: &str = "/usr/sbin/umount";
+
+/*
+ * Create a directory suitable to be chroot'd into, to execute the job.
+ *
+ * The goal of this factory is to run jobs in a multi-user host, but even with
+ * the isolation provided by UNIX users we can't let the jobs run with regular
+ * access to the host's filesystem:
+ *
+ * - One job's temporary files shouldn't interfere with temporary files from
+ *   other jobs or the host, so we'd need isolated /tmp and /var/tmp.
+ *
+ * - Buildomat commits to providing the /work and /input directories to the job,
+ *   but providing them on the host filesystem would mean only one job can run
+ *   in each host at the time, which is not really efficient.
+ *
+ * - As defense-in-depth, it'd be better to enforce on a filesystem level that
+ *   everything except the few directories dedicated to the build are read-only,
+ *   to protect from misconfigured permissions.
+ *
+ * This function prepares a directory with a collection of nested mount points
+ * to provide a read-only view of the filesystem with just a few allowlisted
+ * paths that are writeable.
+ */
+pub(super) fn prepare(
+    central: &Central,
+    worker: WorkerId,
+    user: Uid,
+) -> Result<PathBuf> {
+    let passwd = Passwd::by_uid(user)?
+        .ok_or_else(|| anyhow!("could not locate user {user:?}"))?;
+    let home = passwd
+        .dir
+        .as_deref()
+        .ok_or_else(|| {
+            anyhow!("could not locate home directory of user {user:?}")
+        })?
+        .to_str()
+        .ok_or_else(|| anyhow!("non-UTF-8 home directory for user {user:?}"))?;
+
+    cleanup(central, worker)
+        .context("failed to cleanup before preparing the chroot")?;
+
+    /*
+     * Create the directory that will contain the chroot.  This is owned by the
+     * ephemeral user with mode 0700 to prevent anyone else from accessing it.
+     */
+    let worker_dir = root_dir(worker);
+    std::fs::create_dir_all(&worker_dir)?;
+    chown(&worker_dir, Some(passwd.uid.0), Some(passwd.gid.0))
+        .with_context(|| format!("failed to chown {worker_dir:?}"))?;
+    std::fs::set_permissions(&worker_dir, Permissions::from_mode(0o700))
+        .with_context(|| format!("failed to chmod {worker_dir:?}"))?;
+
+    /*
+     * Create the loopback virtual file system, mapping the root filesystem into
+     * the chroot as a read-only device.  We will add writeable mount points on
+     * top of it to let the build write data.  The root dir's ownership and
+     * permissions match the ones outside the chroot.
+     */
+    let root = worker_dir.join("root");
+    std::fs::create_dir_all(&root)?;
+    chown(&root, Some(0), Some(0))
+        .with_context(|| format!("failed to chown {root:?}"))?;
+    std::fs::set_permissions(&worker_dir, Permissions::from_mode(0o755))
+        .with_context(|| format!("failed to chmod {root:?}"))?;
+    mount("lofs", Path::new("/"), &root, &["-o", "ro"])?;
+
+    /*
+     * The ZFS dataset to store written data is created with sync=disabled to
+     * improve build performance at the cost of data integrity in case of a
+     * sudden power loss.  We don't care about that property for jobs.
+     */
+    let dataset = zfs_dataset_name(central, worker);
+    run(Command::new(ZFS)
+        .args(["create", "-p", "-osync=disabled"])
+        .arg(&dataset))
+    .with_context(|| format!("failed to create ZFS dataset {dataset:?}"))?;
+
+    /*
+     * All temporary directories will be backed by the ZFS dataset created
+     * earlier rather than a tmpfs, to avoid exhausting RAM.
+     */
+    for tmp in ["/tmp", "/var/tmp"] {
+        let src = zfs_dataset_mount(central, worker)
+            .join(tmp.trim_start_matches('/'));
+        std::fs::create_dir_all(&src)?;
+        chown(&src, Some(0), Some(0))?;
+        std::fs::set_permissions(&src, Permissions::from_mode(0o777))?;
+
+        let dest = root.join(tmp.trim_start_matches('/'));
+        mount("lofs", &src, &dest, &[])?;
+    }
+
+    for writable in ["/input", "/work", "/var/run/buildomat", home] {
+        let src = zfs_dataset_mount(central, worker)
+            .join(writable.trim_start_matches('/'));
+        std::fs::create_dir_all(&src)?;
+        chown(&src, Some(passwd.uid.0), Some(passwd.gid.0))?;
+
+        /*
+         * Mounting requires the mount point to be an existing directory.  This
+         * is trickier than it sounds, as we cannot create the directory inside
+         * of the chroot (the loopback mount is read-only!).  We thus have to
+         * create the directory in the root filesystem.
+         */
+        std::fs::create_dir_all(writable)?;
+
+        let dest = root.join(writable.trim_start_matches('/'));
+        mount("lofs", &src, &dest, &[])?;
+    }
+
+    Ok(root)
+}
+
+pub(super) fn cleanup(central: &Central, worker: WorkerId) -> Result<()> {
+    /*
+     * When changing this function, keep in mind that it needs to succeed even
+     * when it was interrupted halfway through in the past, or when there is
+     * nothing left to clean.
+     */
+
+    let root = root_dir(worker);
+    let dataset = zfs_dataset_name(central, worker);
+
+    /*
+     * The chroot contains a read-only loopback mount of / and other mountpoints
+     * nested into it, providing write access to specific directories.  We need
+     * to delete the nested mount points before we delete the parent mount, or
+     * the unmounting will fail.
+     *
+     * Thankfully /etc/mnttab lists mount points ordered by mount time, so if we
+     * process them in reverse we'll do the correct thing.
+     */
+    for path in paths_with_mounts()?.iter().rev() {
+        if path.starts_with(&root) {
+            run(Command::new(UMOUNT).arg(path))
+                .with_context(|| format!("failed to unmount {path:?}"))?;
+        }
+    }
+
+    if list_zfs_datasets()?.contains(&dataset) {
+        run(Command::new(ZFS).arg("destroy").arg(&dataset)).with_context(
+            || format!("failed to destroy ZFS dataset {dataset:?}"),
+        )?;
+    }
+
+    if root.exists() {
+        std::fs::remove_dir_all(&root)
+            .with_context(|| format!("failed to remove {root:?}"))?;
+    }
+
+    Ok(())
+}
+
+fn root_dir(worker: WorkerId) -> PathBuf {
+    Path::new("/var/run/buildomat/worker").join(worker.to_string())
+}
+
+fn zfs_dataset_name(central: &Central, worker: WorkerId) -> String {
+    let parent = central
+        .config
+        .illumos
+        .parent_zfs_dataset
+        .as_deref()
+        .unwrap_or("rpool/buildomat-workers");
+    format!("{parent}/{worker}")
+}
+
+fn zfs_dataset_mount(central: &Central, worker: WorkerId) -> PathBuf {
+    Path::new("/").join(zfs_dataset_name(central, worker))
+}
+
+fn mount(fstype: &str, from: &Path, to: &Path, opts: &[&str]) -> Result<()> {
+    run(Command::new(MOUNT).args(["-F", fstype]).args(opts).arg(from).arg(to))
+        .with_context(|| {
+            format!("failed to mount from {from:?} to {to:?} with {fstype}")
+        })?;
+    Ok(())
+}
+
+fn list_zfs_datasets() -> Result<Vec<String>> {
+    Ok(run(Command::new(ZFS).args(["list", "-H", "-o", "name"]))
+        .context("failed to list ZFS datasets")?
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| line.into())
+        .collect())
+}
+
+fn paths_with_mounts() -> Result<Vec<PathBuf>> {
+    /*
+     * The format of /etc/mnttab is described in mnttab(5).
+     */
+    Ok(std::fs::read_to_string("/etc/mnttab")
+        .context("failed to read mnttab")?
+        .lines()
+        .filter_map(|line| line.split('\t').nth(1))
+        .map(PathBuf::from)
+        .collect())
+}
+
+fn run(cmd: &mut Command) -> Result<String> {
+    let name = cmd.get_program().to_string_lossy().to_string();
+    let output = cmd
+        .output()
+        .with_context(|| format!("failed to spawn command {name:?}"))?;
+    if !output.status.success() {
+        bail!("{name:?} failed: {}", output.info());
+    }
+    output.stdout_string()
+}

--- a/factory/user/src/illumos/mod.rs
+++ b/factory/user/src/illumos/mod.rs
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+mod chroot;
+mod service;
+mod unix;
+mod user;
+
+use crate::bootstrap_agent::BootstrapContext;
+use crate::coordinator::DoNext;
+use crate::db::types::*;
+use crate::illumos::service::{Destroy, InstState};
+use crate::Central;
+use anyhow::{bail, Result};
+use buildomat_common::unix::Passwd;
+use slog::{debug, error, info, warn, Logger};
+use smf::State as SmfState;
+use std::time::{Duration, Instant};
+
+pub(crate) async fn worker_iteration(
+    log: &Logger,
+    c: &Central,
+    id: WorkerId,
+) -> Result<DoNext> {
+    let worker = c.db.worker_get(id)?;
+    let Some(worker) = worker else {
+        bail!("no worker {id} in the database?");
+    };
+
+    match worker.state {
+        WorkerState::Unconfigured => {
+            /*
+             * There is a small chance the slot might not exist, if it was
+             * removed from the configuration file after the worker was created
+             * but before this function was called.
+             */
+            let Some(slot) = c.config.slots.get(&worker.slot) else {
+                error!(log, "worker {id} uses unknown slot {:?}", worker.slot);
+                c.db.worker_new_state(id, WorkerState::Destroying)?;
+                return Ok(DoNext::Immediate);
+            };
+
+            let (uid, gid) = user::create(id, slot)?;
+            let chroot = chroot::prepare(c, id, uid)?;
+
+            let ctx = BootstrapContext {
+                baseurl: c.config.general.baseurl.clone(),
+                bootstrap_token: worker.bootstrap,
+                env: slot.env.clone(),
+                chroot,
+            };
+
+            service::start(id, uid, gid, &ctx)?;
+
+            c.db.worker_new_state(id, WorkerState::Configured)?;
+            info!(log, "configured worker {id}");
+
+            Ok(DoNext::Sleep)
+        }
+        WorkerState::Configured => {
+            let InstState::Present { current, target } = service::state(id)?
+            else {
+                warn!(
+                    log,
+                    "SMF instance for worker {id} disappeared, \
+                     destroying the worker"
+                );
+                c.db.worker_new_state(id, WorkerState::Destroying)?;
+                return Ok(DoNext::Immediate);
+            };
+
+            /*
+             * We don't care about the current state when the service is
+             * transitioning to a new state.
+             */
+            if target.is_some() {
+                return Ok(DoNext::Sleep);
+            }
+
+            match current {
+                Some(SmfState::Online) => Ok(DoNext::Sleep),
+                Some(SmfState::Uninitialized) => {
+                    /*
+                     * This occurs briefly prior to svc.startd(8) picking up the
+                     * new instance.
+                     */
+                    Ok(DoNext::Sleep)
+                }
+                Some(SmfState::Maintenance) => {
+                    /*
+                     * This is a terminal failure state that means the worker is
+                     * not running anymore.
+                     */
+                    warn!(
+                        log,
+                        "SMF instance in maintenance, \
+                         marking worker {id} as broken"
+                    );
+
+                    /*
+                     * Mark the worker as failed on the core server.  This will
+                     * mark the job running on the worker (if any) as failed,
+                     * and hold the worker so that an operator can look at it.
+                     */
+                    c.client
+                        .factory_worker_fail()
+                        .worker(id.to_string())
+                        .body_map(|b| b.reason("SMF service in maintenance"))
+                        .send()
+                        .await?;
+
+                    c.db.worker_new_state(id, WorkerState::Broken)?;
+                    Ok(DoNext::Immediate)
+                }
+                state => {
+                    warn!(log, "SMF instance reached unknown state {state:?}");
+
+                    /*
+                     * Mark the worker as failed on the core server.  This will
+                     * mark the job running on the worker (if any) as failed,
+                     * and hold the worker so that an operator can look at it.
+                     */
+                    c.client
+                        .factory_worker_fail()
+                        .worker(id.to_string())
+                        .body_map(|b| {
+                            b.reason(format!(
+                                "SMF instance reached unknown state {state:?}"
+                            ))
+                        })
+                        .send()
+                        .await?;
+                    c.db.worker_new_state(id, WorkerState::Broken)?;
+
+                    Ok(DoNext::Immediate)
+                }
+            }
+        }
+        WorkerState::Destroying => {
+            match service::destroy(log, id)? {
+                Destroy::Destroying => return Ok(DoNext::Sleep),
+                Destroy::Destroyed => {}
+            }
+
+            /*
+             * While we have disabled the service, it is possible that some
+             * processes could have been created outside the contract.  Ensure
+             * all processes for the build user are terminated and then remove
+             * any files left behind.
+             */
+            if let Some(user) = Passwd::by_name(&user::name(id))? {
+                kill_all(log, &user).await?;
+            }
+
+            chroot::cleanup(c, id)?;
+            user::remove(id)?;
+
+            info!(log, "worker {id} successfully destroyed");
+            c.db.worker_new_state(id, WorkerState::Destroyed)?;
+            Ok(DoNext::Immediate)
+        }
+        WorkerState::Broken => {
+            /*
+             * We will remain in the broken state until the core server decides
+             * to recycle the worker.
+             */
+            Ok(DoNext::Sleep)
+        }
+        WorkerState::Destroyed => {
+            /*
+             * The coordinator will take care of stopping the task instead of
+             * sleeping when it's time for it to
+             */
+            Ok(DoNext::Sleep)
+        }
+    }
+}
+
+async fn kill_all(log: &Logger, u: &Passwd) -> Result<()> {
+    let user = if let Some(name) = &u.name {
+        format!("user {name} (uid {})", u.uid.0)
+    } else {
+        format!("uid {}", u.uid.0)
+    };
+
+    let id = unix::SigSendId::UserId(u.uid.0);
+    if unix::sigsend_maybe(id, libc::SIGKILL)? {
+        debug!(log, "killed leftover processes for {user}");
+
+        /*
+         * There are a number of reasons that processes might linger for a
+         * little while in the table after we terminate them.  Wait for a bit to
+         * make sure they're all gone:
+         */
+        let start = Instant::now();
+        while Instant::now().saturating_duration_since(start).as_secs() < 10 {
+            /*
+             * Try with the 0 argument, which can be used to confirm that no
+             * processes exist.
+             */
+            if !unix::sigsend_maybe(id, 0)? {
+                return Ok(());
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        bail!("processes for {user} still exist?");
+    }
+
+    Ok(())
+}

--- a/factory/user/src/illumos/service.rs
+++ b/factory/user/src/illumos/service.rs
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use crate::bootstrap_agent::BootstrapContext;
+use crate::db::types::WorkerId;
+use anyhow::{anyhow, Result};
+use buildomat_common::unix::{Gid, Uid};
+use slog::{info, Logger};
+use smf::scf_type_t::{SCF_TYPE_ASTRING, SCF_TYPE_BOOLEAN};
+use smf::{CommitResult, Instance, Scf, State, Transaction};
+
+const SMF_SERVICE: &str = "site/buildomat/factory-user-worker";
+
+pub(super) fn start(
+    id: WorkerId,
+    uid: Uid,
+    gid: Gid,
+    ctx: &BootstrapContext,
+) -> Result<()> {
+    let scf = Scf::new()?;
+    let scope = scf.scope_local()?;
+    let service = scope
+        .get_service(SMF_SERVICE)?
+        .ok_or_else(|| anyhow!("missing SMF service {SMF_SERVICE:?}"))?;
+
+    let instance = match service.get_instance(&instance_name(id))? {
+        Some(instance) => instance,
+        None => service.add_instance(&instance_name(id))?,
+    };
+
+    /*
+     * Unfortunately the SMF crate doesn't have a method to get a
+     * property group by name, so we have to search all of them.
+     */
+    let pg_svc_start = service
+        .pgs()?
+        .flat_map(|result| result.ok())
+        .find(|pg| pg.name().ok().as_deref() == Some("start"))
+        .ok_or_else(|| anyhow!("missing \"start\" service property group"))?;
+
+    edit_property_group(&instance, "start", "framework", |tx| {
+        /*
+         * When the instance is created there is no "start" property group at
+         * the instance level, only at the service level.
+         *
+         * Unfortunately, creating the group in the instance doesn't inherit
+         * properties from the service, so we have to do that ourselves.
+         * Otherwise, properties defined at the service level would disappear.
+         */
+        for property in pg_svc_start.properties()? {
+            let property = property?;
+            if let Some(value) = property.value()? {
+                tx.property_ensure(
+                    &property.name()?,
+                    property.type_()?,
+                    &value.as_string()?,
+                )?;
+            };
+        }
+
+        /*
+         * Set the user and group the SMF instance will run as.
+         */
+        tx.property_ensure("use_profile", SCF_TYPE_BOOLEAN, "false")?;
+        tx.property_ensure("user", SCF_TYPE_ASTRING, &uid.0.to_string())?;
+        tx.property_ensure("group", SCF_TYPE_ASTRING, &gid.0.to_string())?;
+
+        Ok(())
+    })?;
+
+    edit_property_group(&instance, "buildomat", "application", |tx| {
+        let BootstrapContext { baseurl, bootstrap_token, chroot, env: _ } = ctx;
+
+        tx.property_ensure("baseurl", SCF_TYPE_ASTRING, baseurl)?;
+        tx.property_ensure(
+            "bootstrap_token",
+            SCF_TYPE_ASTRING,
+            bootstrap_token,
+        )?;
+        tx.property_ensure(
+            "chroot",
+            SCF_TYPE_ASTRING,
+            chroot
+                .to_str()
+                .ok_or_else(|| anyhow!("non-UTF-8 path: {chroot:?}"))?,
+        )?;
+        Ok(())
+    })?;
+
+    /*
+     * To avoid losing the key/value structure of environment variables, create
+     * a separate property group for them.
+     */
+    edit_property_group(&instance, "buildomat-env", "application", |tx| {
+        for (key, value) in &ctx.env {
+            tx.property_ensure(key, SCF_TYPE_ASTRING, value)?;
+        }
+        Ok(())
+    })?;
+
+    /*
+     * When creating an instance of a service, it's created in the SMF
+     * repository database (svc.configd) but it doesn't seem to end up fully
+     * initialised by the restarter daemon (svc.startd) unless the restarter is
+     * told to do something.  That causes weird errors when attempting to look
+     * at the state of the service.
+     *
+     * The presence of a running snapshot indicates the restarter daemon knows
+     * about the service, so if none is present we do any action to let the
+     * restarter the service actually exists.
+     */
+    if instance.get_running_snapshot().is_err() {
+        instance.disable(false)?;
+    }
+
+    instance.enable(false)?;
+
+    Ok(())
+}
+
+pub(super) fn state(id: WorkerId) -> Result<InstState> {
+    let scf = Scf::new()?;
+    let scope = scf.scope_local()?;
+    let service = scope
+        .get_service(SMF_SERVICE)?
+        .ok_or_else(|| anyhow!("missing SMF service {SMF_SERVICE:?}"))?;
+
+    let Some(instance) = service.get_instance(&instance_name(id))? else {
+        return Ok(InstState::Missing);
+    };
+
+    let (current, target) = instance.states()?;
+    Ok(InstState::Present { current, target })
+}
+
+pub(super) fn destroy(log: &Logger, id: WorkerId) -> Result<Destroy> {
+    let scf = Scf::new()?;
+    let scope = scf.scope_local()?;
+    let service = scope
+        .get_service(SMF_SERVICE)?
+        .ok_or_else(|| anyhow!("missing SMF service {SMF_SERVICE:?}"))?;
+
+    let Some(instance) = service.get_instance(&instance_name(id))? else {
+        return Ok(Destroy::Destroyed);
+    };
+
+    let (current, target) = instance.states()?;
+    if target.is_some() {
+        return Ok(Destroy::Destroying);
+    }
+    match current {
+        Some(State::Disabled | State::Maintenance) => {
+            /*
+             * This is a terminal state and we can delete the
+             * service instance.
+             */
+            instance.delete()?;
+            Ok(Destroy::Destroyed)
+        }
+        _ => {
+            info!(log, "disabling SMF instance for worker {id}");
+            instance.disable(true)?;
+            Ok(Destroy::Destroying)
+        }
+    }
+}
+
+fn edit_property_group(
+    instance: &Instance<'_>,
+    name: &str,
+    pgtype: &str,
+    edit: impl Fn(&Transaction<'_>) -> Result<()>,
+) -> Result<()> {
+    let pg = match instance.get_pg(name)? {
+        Some(pg) => pg,
+        None => instance.add_pg(name, pgtype)?,
+    };
+    loop {
+        let tx = pg.transaction()?;
+        tx.start()?;
+        edit(&tx)?;
+        match tx.commit()? {
+            CommitResult::Success => break,
+            CommitResult::OutOfDate => pg.update()?,
+        }
+    }
+    Ok(())
+}
+
+fn instance_name(id: WorkerId) -> String {
+    format!("bmat-{id}")
+}
+
+pub(super) enum InstState {
+    Missing,
+    Present { current: Option<State>, target: Option<State> },
+}
+
+pub(super) enum Destroy {
+    Destroying,
+    Destroyed,
+}

--- a/factory/user/src/illumos/unix.rs
+++ b/factory/user/src/illumos/unix.rs
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use anyhow::{bail, Result};
+
+#[cfg(target_os = "illumos")]
+mod sys {
+    use libc::{c_int, id_t, idtype_t};
+
+    pub const P_UID: idtype_t = 5;
+
+    extern "C" {
+        pub fn sigsend(idtype: idtype_t, id: id_t, sig: c_int) -> c_int;
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SigSendId {
+    UserId(u32),
+}
+
+#[cfg(target_os = "illumos")]
+pub fn sigsend_maybe(id: SigSendId, sig: i32) -> Result<bool> {
+    let (idtype, id) = match id {
+        SigSendId::UserId(uid) => (sys::P_UID, uid as i32),
+    };
+
+    if unsafe { sys::sigsend(idtype, id, sig) } == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ESRCH) => {
+            /*
+             * No processes were found that matched the criteria.
+             */
+            Ok(false)
+        }
+        _ => bail!("sigsend({idtype}, {id}, {sig})): {error}"),
+    }
+}
+
+#[cfg(not(target_os = "illumos"))]
+pub fn sigsend_maybe(_id: SigSendId, _sig: i32) -> Result<bool> {
+    bail!("only works on illumos systems");
+}

--- a/factory/user/src/illumos/user.rs
+++ b/factory/user/src/illumos/user.rs
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Oxide Computer Company
+ */
+
+use crate::config::ConfigFileSlot;
+use crate::db::types::WorkerId;
+use anyhow::{bail, Context as _, Result};
+use buildomat_common::unix::{Gid, Uid};
+use rand::RngExt as _;
+use std::ops::Range;
+use std::path::Path;
+use std::process::Command;
+
+const ID_RANGE: Range<u32> = 2u32.pow(20)..2u32.pow(30);
+
+pub(super) fn create(
+    worker: WorkerId,
+    slot: &ConfigFileSlot,
+) -> Result<(Uid, Gid)> {
+    remove(worker).context("failed to cleanup users before creating them")?;
+
+    let gid = loop {
+        let gid = rand::rng().random_range(ID_RANGE);
+
+        let output = Command::new("/usr/sbin/groupadd")
+            .arg("-g")
+            .arg(gid.to_string())
+            .arg(name(worker))
+            .output()
+            .context("failed to spawn groupadd")?;
+
+        match output.status.code() {
+            Some(0) => break gid,
+            /*
+             * Exit status of 4 indicates the random gid we generated already
+             * exists: reroll another one in the next iteration.
+             */
+            Some(4) => continue,
+            _ => {
+                bail!(
+                    "adding group {:?} exited with {}: {}",
+                    name(worker),
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+        }
+    };
+
+    let home = Path::new("/home").join(name(worker));
+    let uid = loop {
+        let uid = rand::rng().random_range(ID_RANGE);
+
+        let mut cmd = Command::new("/usr/sbin/useradd");
+        cmd.arg("-u").arg(uid.to_string());
+        cmd.arg("-d").arg(&home);
+        cmd.arg("-g").arg(gid.to_string());
+        for group in &slot.add_to_groups {
+            cmd.arg("-G").arg(group);
+        }
+        cmd.arg(name(worker));
+
+        let output = cmd.output().context("failed to spawn useradd")?;
+        match output.status.code() {
+            Some(0) => break uid,
+            /*
+             * Exit status of 4 indicates the random gid we generated already
+             * exists: reroll another one in the next iteration.
+             */
+            Some(4) => continue,
+            _ => {
+                bail!(
+                    "adding user {:?} exited with {}: {}",
+                    name(worker),
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+        }
+    };
+
+    Ok((Uid(uid), Gid(gid)))
+}
+
+pub(super) fn remove(worker: WorkerId) -> Result<()> {
+    let userdel = Command::new("/usr/sbin/userdel")
+        .arg(name(worker))
+        .output()
+        .context("failed to invoke userdel")?;
+    match userdel.status.code() {
+        Some(0) => {}
+        /*
+         * Exit status of 6 indicates that the user doesn't exist.
+         */
+        Some(6) => {}
+        _ => {
+            bail!(
+                "deleting group {:?} exited with {}: {}",
+                name(worker),
+                userdel.status,
+                String::from_utf8_lossy(&userdel.stderr),
+            );
+        }
+    }
+
+    let groupdel = Command::new("/usr/sbin/groupdel")
+        .arg(name(worker))
+        .output()
+        .context("failed to invoke groupdel")?;
+    match groupdel.status.code() {
+        Some(0) => {}
+        /*
+         * Exit status of 6 indicates that the group doesn't exist.
+         */
+        Some(6) => {}
+        _ => {
+            bail!(
+                "deleting group {:?} exited with {}: {}",
+                name(worker),
+                groupdel.status,
+                String::from_utf8_lossy(&groupdel.stderr),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn name(worker: WorkerId) -> String {
+    format!("bmat-{worker}")
+}

--- a/factory/user/src/main.rs
+++ b/factory/user/src/main.rs
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Oxide Computer
+ */
+
+use crate::config::{validate_config, ConfigFile};
+use crate::coordinator::coordinator_loop;
+use crate::db::Database;
+use crate::factory::factory_loop;
+use anyhow::{bail, Result};
+use buildomat_common::*;
+use getopts::Options;
+use slog::Logger;
+use std::{sync::Arc, time::Duration};
+
+mod bootstrap_agent;
+mod config;
+mod coordinator;
+mod db;
+mod factory;
+mod illumos;
+
+struct Central {
+    log: Logger,
+    client: buildomat_client::Client,
+    config: ConfigFile,
+    db: Database,
+}
+
+/*
+ * This factory may run on large AMD machines (e.g., 100+ SMT threads) and thus
+ * could up with far too many worker threads by default.
+ */
+#[tokio::main(worker_threads = 4)]
+async fn main() -> Result<()> {
+    usdt::register_probes().unwrap();
+
+    if std::env::args().nth(1).as_deref() == Some("__bootstrap_agent") {
+        bootstrap_agent::run().await?;
+        return Ok(());
+    }
+
+    let mut opts = Options::new();
+
+    opts.optopt("f", "", "configuration file", "CONFIG");
+    opts.optopt("d", "", "database file", "FILE");
+
+    let p = match opts.parse(std::env::args().skip(1)) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("ERROR: usage: {}", e);
+            eprintln!("       {}", opts.usage("usage"));
+            std::process::exit(1);
+        }
+    };
+
+    let log = make_log("factory-user");
+
+    let config: ConfigFile = if let Some(f) = p.opt_str("f").as_deref() {
+        read_toml(f)?
+    } else {
+        bail!("must specify configuration file (-f)");
+    };
+    validate_config(&config)?;
+
+    let db = if let Some(p) = p.opt_str("d") {
+        Database::new(log.clone(), p, None)?
+    } else {
+        bail!("must specify database file (-d)");
+    };
+
+    let client = buildomat_client::ClientBuilder::new(&config.general.baseurl)
+        .bearer_token(&config.factory.token)
+        .build()?;
+
+    /*
+     * Install a custom panic hook that will try to exit the process after a
+     * short delay.  This is unfortunate, but I am not sure how else to avoid a
+     * panicked worker thread leaving the process stuck without some of its
+     * functionality.
+     */
+    let orig_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        orig_hook(info);
+        eprintln!("FATAL: THREAD PANIC DETECTED; EXITING IN 5 SECONDS...");
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(5));
+            std::process::exit(101);
+        });
+    }));
+
+    let c = Arc::new(Central { log, config, client, db });
+
+    let t_coordinator = tokio::spawn(coordinator_loop(Arc::clone(&c)));
+    let t_factory = tokio::spawn(factory_loop(Arc::clone(&c)));
+
+    tokio::select! {
+        _ = t_coordinator => bail!("coordinator task stopped early"),
+        _ = t_factory => bail!("factory task stopped early"),
+    }
+}

--- a/server/src/api/factory.rs
+++ b/server/src/api/factory.rs
@@ -270,6 +270,53 @@ pub(crate) async fn factory_worker_flush(
     Ok(HttpResponseUpdatedNoContent())
 }
 
+#[derive(Deserialize, Serialize, JsonSchema)]
+pub(crate) struct FactoryWorkerFail {
+    reason: String,
+}
+
+#[endpoint {
+    method = POST,
+    path = "/0/factory/worker/{worker}/fail",
+}]
+pub(crate) async fn factory_worker_fail(
+    rqctx: RequestContext<Arc<Central>>,
+    path: TypedPath<WorkerPath>,
+    body: TypedBody<FactoryWorkerFail>,
+) -> DSResult<HttpResponseUpdatedNoContent> {
+    let c = rqctx.context();
+    let log = &rqctx.log;
+
+    let worker_id = path.into_inner().worker()?;
+    let reason = body.into_inner().reason;
+
+    let factory = c.require_factory(log, &rqctx.request).await?;
+    let worker = c.db.worker(worker_id).or_500()?;
+    factory.owns(log, &worker)?;
+
+    warn!(
+        log, "worker failed!";
+        "id" => worker.id.to_string(), "reason" => &reason,
+    );
+
+    /*
+     * Record in the database that the worker has failed.  This routine will
+     * take care of reporting failure in any assigned jobs, marking the worker
+     * as held, etc.
+     */
+    let failed_jobs = c.db.worker_mark_failed(worker.id, &reason).or_500()?;
+    if !failed_jobs.is_empty() {
+        let jobs = failed_jobs
+            .into_iter()
+            .map(|j| j.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        warn!(log, "worker {} failing caused jobs {jobs} to fail", worker.id);
+    }
+
+    Ok(HttpResponseUpdatedNoContent())
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct FactoryWorkerAssociate {
     private: String,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1011,6 +1011,7 @@ async fn main() -> Result<()> {
     ad.register(api::factory::factory_ping)?;
     ad.register(api::factory::factory_worker_create)?;
     ad.register(api::factory::factory_worker_append)?;
+    ad.register(api::factory::factory_worker_fail)?;
     ad.register(api::factory::factory_worker_flush)?;
     ad.register(api::factory::factory_worker_associate)?;
     ad.register(api::factory::factory_worker_destroy)?;


### PR DESCRIPTION
This PR implements a new factory for buildomat, spawning jobs in ephemeral users in the same host system running the factory. Documentation on how to use the factory is available in the factory README.

I was careful during the implementation of the factory to make sure it will always attempt to clean up after itself (never releasing a slot until the cleanup stage finishes) and that it alerts the operator when something goes wrong (by failing the worker, which triggers an hold on it: I plan in the future to add monitoring for held workers).

This PR also makes multiple changes to the agent installation to support this, each in its separate commit. I can move those to a single separate PR or multiple separate PRs if you'd prefer.

The implementation of the factory was based on @jclulow's 2024 work on a work-in-progress hubris factory.