### PR TITLE
gimlet: wait for postboot to come online needs more work

### DIFF
--- a/factory/gimlet/src/host.rs
+++ b/factory/gimlet/src/host.rs
@@ -924,7 +924,7 @@ impl HostManager {
                 let pb = sys
                     .ssh_exec("svcs -Ho sta,nsta svc:/site/postboot:default")?;
                 let t = pb.out.split_whitespace().collect::<Vec<_>>();
-                if t.len() != 2 || t[0] == "ON" || t[1] == "-" {
+                if t.len() != 2 || t[0] != "ON" || t[1] != "-" {
                     bail!("postboot not ready: {t:?}");
                 }
 
@@ -1007,7 +1007,7 @@ impl HostManager {
                 let pb = sys
                     .ssh_exec("svcs -Ho sta,nsta svc:/site/postboot:default")?;
                 let t = pb.out.split_whitespace().collect::<Vec<_>>();
-                if t.len() != 2 || t[0] == "ON" || t[1] == "-" {
+                if t.len() != 2 || t[0] != "ON" || t[1] != "-" {
                     bail!("postboot not ready: {t:?}");
                 }
 


### PR DESCRIPTION
The **gimlet** factory attempts to wait for the **postboot** service on the controlled sled to come online.  Unfortunately the check for this condition is just completely wrong today.

I noticed because one of the Gimlets came to rest reporting that postboot was not ready, but with a state that looked very ready to me; i.e., `["ON", "-"]`.  As far as I can tell, the postboot service is essentially never ready at the moment we start polling its status, so we erroneously move on to the next state in the state machine automatically -- except this time, where it was, and it got stuck.