### PR TITLE
github: hide private repository details from the status page

### DIFF
--- a/github/database/schema.sql
+++ b/github/database/schema.sql
@@ -87,3 +87,7 @@ ALTER TABLE check_run ADD COLUMN
 
 -- v 13
 CREATE INDEX check_run_check_suite ON check_run (check_suite);
+
+-- v 14
+ALTER TABLE repository ADD COLUMN
+    visibility      TEXT;

--- a/github/database/src/lib.rs
+++ b/github/database/src/lib.rs
@@ -358,9 +358,14 @@ impl Database {
         id: i64,
         owner: &str,
         name: &str,
+        visibility: &str,
     ) -> DBResult<()> {
-        let r =
-            Repository { id, owner: owner.to_string(), name: name.to_string() };
+        let r = Repository {
+            id,
+            owner: owner.to_string(),
+            name: name.to_string(),
+            visibility: Some(visibility.to_string()),
+        };
 
         self.sql.tx(|h| {
             h.exec_insert(
@@ -369,6 +374,7 @@ impl Database {
                         OnConflict::column(RepositoryDef::Id)
                             .update_column(RepositoryDef::Name)
                             .update_column(RepositoryDef::Owner)
+                            .update_column(RepositoryDef::Visibility)
                             .to_owned(),
                     )
                     .to_owned(),

--- a/github/database/src/tables/repository.rs
+++ b/github/database/src/tables/repository.rs
@@ -10,19 +10,25 @@ pub struct Repository {
     pub id: i64,
     pub owner: String,
     pub name: String,
+    pub visibility: Option<String>,
 }
 
 impl FromRow for Repository {
     fn columns() -> Vec<ColumnRef> {
-        [RepositoryDef::Id, RepositoryDef::Owner, RepositoryDef::Name]
-            .into_iter()
-            .map(|col| {
-                ColumnRef::TableColumn(
-                    SeaRc::new(RepositoryDef::Table),
-                    SeaRc::new(col),
-                )
-            })
-            .collect()
+        [
+            RepositoryDef::Id,
+            RepositoryDef::Owner,
+            RepositoryDef::Name,
+            RepositoryDef::Visibility,
+        ]
+        .into_iter()
+        .map(|col| {
+            ColumnRef::TableColumn(
+                SeaRc::new(RepositoryDef::Table),
+                SeaRc::new(col),
+            )
+        })
+        .collect()
     }
 
     fn from_row(row: &Row) -> rusqlite::Result<Self> {
@@ -30,6 +36,7 @@ impl FromRow for Repository {
             id: row.get(0)?,
             owner: row.get(1)?,
             name: row.get(2)?,
+            visibility: row.get(3)?,
         })
     }
 }
@@ -51,6 +58,7 @@ impl Repository {
                 self.id.into(),
                 self.owner.clone().into(),
                 self.name.clone().into(),
+                self.visibility.clone().into(),
             ])
             .to_owned()
     }

--- a/github/dbtool/src/main.rs
+++ b/github/dbtool/src/main.rs
@@ -334,6 +334,7 @@ async fn do_repository_list(mut l: Level<Stuff>) -> Result<()> {
     l.add_column("id", 10, true);
     l.add_column("owner", 36, true);
     l.add_column("name", 36, true);
+    l.add_column("visibility", 10, true);
 
     let a = no_args!(l);
     let mut t = a.table();
@@ -343,6 +344,7 @@ async fn do_repository_list(mut l: Level<Stuff>) -> Result<()> {
         r.add_u64("id", repo.id as u64);
         r.add_str("owner", repo.owner);
         r.add_str("name", repo.name);
+        r.add_str("visibility", repo.visibility.as_deref().unwrap_or("-"));
 
         t.add_row(r);
     }

--- a/github/hooktypes/src/lib.rs
+++ b/github/hooktypes/src/lib.rs
@@ -79,6 +79,7 @@ pub struct Repository {
     pub node_id: String,
     pub name: String,
     pub owner: Owner,
+    pub visibility: String,
 }
 
 #[derive(Deserialize, Debug)]

--- a/github/server/src/http.rs
+++ b/github/server/src/http.rs
@@ -566,6 +566,14 @@ async fn status_impl(
         .collect::<HashMap<_, _>>();
     let mut users: HashMap<String, String> = Default::default();
 
+    fn github_repo(
+        app: &App,
+        tags: &HashMap<String, String>,
+    ) -> Option<Repository> {
+        let repo_id = tags.get("gong.repo.id")?.parse().ok()?;
+        app.db.load_repository(repo_id).ok()
+    }
+
     fn github_url(tags: &HashMap<String, String>) -> Option<String> {
         let owner = tags.get("gong.repo.owner")?;
         let name = tags.get("gong.repo.name")?;
@@ -604,19 +612,35 @@ async fn status_impl(
         Some(out)
     }
 
-    fn dump_info(job: &buildomat_client::types::Job) -> String {
+    fn dump_info(app: &App, job: &buildomat_client::types::Job) -> String {
         let tags = &job.tags;
 
         let mut out = String::new();
-        if let Some(info) = github_info(tags) {
-            out += &format!("&nbsp;&nbsp;&nbsp;<b>{}</b><br>\n", info);
+
+        if let Some(repo) = github_repo(app, tags) {
+            if repo.visibility.as_deref() == Some("public") {
+                if let Some(info) = github_info(tags) {
+                    out += &format!("&nbsp;&nbsp;&nbsp;<b>{}</b><br>\n", info);
+                }
+                if let Some(url) = commit_url(tags) {
+                    out += &format!(
+                        "&nbsp;&nbsp;&nbsp;<b>commit:</b> {}<br>\n",
+                        url
+                    );
+                }
+                if let Some(url) = github_url(tags) {
+                    out +=
+                        &format!("&nbsp;&nbsp;&nbsp;<b>url:</b> {}<br>\n", url);
+                }
+            } else {
+                out += "&nbsp;&nbsp;&nbsp;<i>This build is linked to a \
+                        private GitHub repository.</i><br>\n";
+            }
+        } else {
+            out += "&nbsp;&nbsp;&nbsp;<i>This build is not linked to a \
+                    GitHub repository.</i><br>\n";
         }
-        if let Some(url) = commit_url(tags) {
-            out += &format!("&nbsp;&nbsp;&nbsp;<b>commit:</b> {}<br>\n", url);
-        }
-        if let Some(url) = github_url(tags) {
-            out += &format!("&nbsp;&nbsp;&nbsp;<b>url:</b> {}<br>\n", url);
-        }
+
         if job.target == job.target_real {
             out += &format!(
                 "&nbsp;&nbsp;&nbsp;<b>target:</b> {}<br>\n",
@@ -723,7 +747,7 @@ async fn status_impl(
                         users.get(&job.owner).unwrap()
                     );
                     if let Some(job) = jobs.iter().find(|j| j.id == job.id) {
-                        out += &dump_info(job);
+                        out += &dump_info(app, job);
                     }
                     out += "<br>\n";
                 }
@@ -784,7 +808,7 @@ async fn status_impl(
             out += "<li>";
             out +=
                 &format!("{} user {}", job.id, users.get(&job.owner).unwrap());
-            out += &dump_info(job);
+            out += &dump_info(app, job);
             out += "<br>\n";
         }
 
@@ -820,7 +844,7 @@ async fn status_impl(
             " <span style=\"background-color: #{}\">[{}]</span>",
             colour, word
         );
-        out += &dump_info(job);
+        out += &dump_info(app, job);
         out += "<br>\n";
     }
     out += "</ul>\n";

--- a/github/server/src/main.rs
+++ b/github/server/src/main.rs
@@ -447,6 +447,7 @@ async fn process_deliveries(app: &Arc<App>) -> Result<()> {
                         repo.id,
                         &repo.owner.login,
                         &repo.name,
+                        &repo.visibility,
                     )?;
                 };
                 app.db.delivery_ack(del.seq, ack)?;
@@ -479,6 +480,7 @@ async fn process_deliveries(app: &Arc<App>) -> Result<()> {
                         repo.id,
                         &repo.owner.login,
                         &repo.name,
+                        &repo.visibility,
                     )?;
                     repo
                 } else {
@@ -536,6 +538,7 @@ async fn process_deliveries(app: &Arc<App>) -> Result<()> {
                     pr.head.repo().id,
                     &pr.head.repo().owner.login,
                     &pr.head.repo().name,
+                    &pr.head.repo().visibility,
                 )?;
 
                 let gh = app.install_client(instid);
@@ -952,6 +955,7 @@ async fn process_deliveries(app: &Arc<App>) -> Result<()> {
                         repo.id,
                         &repo.owner.login,
                         &repo.name,
+                        &repo.visibility,
                     )?;
                     repo
                 } else {


### PR DESCRIPTION
This PR starts tracking the visibility of GitHub repositories in the database, and hides detailed information about builds from the status page if those builds originated from a private or internal repository. Example how how it looks like:

<img width="574" height="236" alt="image" src="https://github.com/user-attachments/assets/79607a47-13ac-491a-a9ff-8121c574b9ae" />

Note that this PR doesn't backfill the visibility of existing repository, it only updates it when we receive a webhook about it. I did this because in production we are tracking ~2700 repositories in the database (mostly forks of public repos we give buildomat to), and querying the visibility of all of them would take long and possibly get us close to the rate limits.

I don't think the lack of backfill is a huge problem, as the visibility is currently relied upon just for the status page (which lists at most 100 existing jobs, so any inconsistency would quickly disappear as new webhooks with jobs come in), and any future use will be triggered by a webhook that'd update the visibility anyway.

If you feel strongly I can add some backfilling code. This PR is best reviewed commit-by-commit.