### PR TITLE
github: recognise possible reserved status values for checks

### DIFF
--- a/github/hooktypes/src/lib.rs
+++ b/github/hooktypes/src/lib.rs
@@ -148,14 +148,15 @@ pub enum PullRequestState {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckSuiteStatus {
-    Requested,
+    Queued,
     InProgress,
     Completed,
-    Queued,
     /*
-     * This status is not documented, and does not appear in the schema,
-     * but GitHub Actions (of course) seems to generate it sometimes:
+     * These status values are reserved for GitHub Actions, but do for whatever
+     * reason still sometimes appear in events we receive:
      */
+    Waiting,
+    Requested,
     Pending,
 }
 
@@ -166,9 +167,11 @@ pub enum CheckRunStatus {
     InProgress,
     Completed,
     /*
-     * This status is not documented, and does not appear in the schema,
-     * but GitHub Actions (of course) seems to generate it sometimes:
+     * These status values are reserved for GitHub Actions, but do for whatever
+     * reason still sometimes appear in events we receive:
      */
+    Waiting,
+    Requested,
     Pending,
 }
 


### PR DESCRIPTION
At some point we received at least one webhook delivery for a check with a GitHub-reserved status value.

```
12:39:06.276Z ERRO github-server: delivery 6657697 event check_run: unknown variant `waiting`, expected one of `queued`, `in_progress`, `completed`, `pending`
12:39:06.276Z ERRO github-server: delivery 6669700 event check_run: unknown variant `waiting`, expected one of `queued`, `in_progress`, `completed`, `pending`
12:39:06.276Z ERRO github-server: delivery 6711268 event check_run: unknown variant `waiting`, expected one of `queued`, `in_progress`, `completed`, `pending`
```

So that we can process and ignore these, this change includes the reserved values that have at some point been documented.