### PR TITLE
github: handle more kinds of incomplete events

### DIFF
--- a/github/dbtool/src/main.rs
+++ b/github/dbtool/src/main.rs
@@ -297,7 +297,11 @@ async fn do_delivery_list(mut l: Level<Stuff>) -> Result<()> {
         match serde_json::from_value::<hooktypes::Payload>(del.payload.0) {
             Ok(payload) => {
                 r.add_str("action", &payload.action);
-                r.add_str("sender", &payload.sender.login);
+                if let Some(sender) = &payload.sender {
+                    r.add_str("sender", &sender.login);
+                } else {
+                    r.add_str("sender", "-");
+                }
                 if let Some(inst) = &payload.installation {
                     r.add_str("install", inst.id.to_string());
                 } else {

--- a/github/hooktypes/src/lib.rs
+++ b/github/hooktypes/src/lib.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 pub struct Payload {
     #[serde(default)]
     pub action: String,
-    pub sender: User,
+    pub sender: Option<User>,
     pub repository: Option<Repository>,
     pub installation: Option<Installation>,
     pub check_suite: Option<CheckSuite>,
@@ -115,11 +115,11 @@ pub struct PullRequest {
 
 #[derive(Deserialize, Debug)]
 pub struct PullRequestCommit {
-    pub label: String,
+    pub label: Option<String>,
     #[serde(rename = "ref")]
     pub ref_: String,
     pub sha: String,
-    pub user: User,
+    pub user: Option<User>,
     pub repo: Option<Repository>,
 }
 


### PR DESCRIPTION
We have on occasion received events from GitHub that pretty heavily imply they are not using a strongly typed language in enough of their inner workings.  Recently, we received a pull request event where the **sender** field was entirely absent, and the **head** of the pull request was not completely filled out:

```
            head: PullRequestCommit {
                label: None,
                ref_: "tracing-appender-localtime",
                sha: "6b77405e825846c4e6e2cc1ca9544287ef54c12c",
                user: None,
                repo: None,
            },
```

As we don't currently _need_ those fields, we can just make them optional.